### PR TITLE
refactor(seo): centralize SITE_URL into shared constant

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import Footer from '@/components/Footer';
 import Header from '@/components/Header';
+import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { GeistMono } from 'geist/font/mono';
@@ -7,7 +8,6 @@ import { GeistSans } from 'geist/font/sans';
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
-const SITE_URL = 'https://olivierwinkler.ch';
 const title = 'Olivier Winkler — Software Engineer';
 const description =
   'Software Engineer building products for the future. Building frigg.eco — sustainable technology for a better world.';

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,3 +1,4 @@
+import { SITE_URL } from '@/lib/site';
 import type { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
@@ -7,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: ['/api/'],
     },
-    sitemap: 'https://olivierwinkler.ch/sitemap.xml',
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,5 @@
+import { SITE_URL } from '@/lib/site';
 import type { MetadataRoute } from 'next';
-
-const SITE_URL = 'https://olivierwinkler.ch';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,1 @@
+export const SITE_URL = 'https://olivierwinkler.ch';


### PR DESCRIPTION
## Summary
While investigating a Google Search Console "Page with redirect" notice, we confirmed the domain setup is already correct (Vercel edge handles HTTP→HTTPS and the www→apex 301), so no redirect or canonical fix was needed. This PR keeps only the small maintainability win found along the way.

## Changes
- Add `src/lib/site.ts` exporting a single `SITE_URL` constant.
- Import shared `SITE_URL` in `layout.tsx`, `sitemap.ts`, and `robots.ts`, removing the domain literal that was duplicated in three places.

## Additional Notes
Pure refactor with no behavior change — `/sitemap.xml`, `/robots.txt`, and the homepage canonical tag render identically, and `pnpm build` + TypeScript pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)