### PR TITLE
refactor(projects): make the data layer hold more than one project

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prettier": "prettier --write --ignore-path .gitignore .",
+    "prettier": "prettier --write .",
     "vocab:wo-haere": "node scripts/wo-haere-vocab.mjs"
   },
   "dependencies": {

--- a/src/app/(site)/projects/page.tsx
+++ b/src/app/(site)/projects/page.tsx
@@ -23,16 +23,18 @@ export default function ProjectsPage() {
       </p>
 
       <ul className="mt-12 flex flex-col gap-12">
-        {projects.map(project => (
+        {projects.map((project, index) => (
           <li key={project.slug}>
-            <Link href={project.href} className="group block">
+            <Link href={`/projects/${project.slug}`} className="group block">
               <Image
                 src={project.cover.src}
                 width={project.cover.width}
                 height={project.cover.height}
                 alt={project.cover.alt}
                 className="w-full rounded-lg border border-white/20 transition-colors group-hover:border-white/50"
-                priority
+                // Only the first cover is above the fold; preloading the rest
+                // just makes them compete for the same connection.
+                priority={index === 0}
               />
               <div className="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
                 <h2 className="text-2xl font-medium">{project.title}</h2>

--- a/src/app/(site)/projects/wo-haere/page.tsx
+++ b/src/app/(site)/projects/wo-haere/page.tsx
@@ -1,10 +1,9 @@
+import ProjectLinks from '@/components/projects/Links';
+import { A, P, Section, Shot, Table } from '@/components/projects/Prose';
 import { getProject } from '@/data/projects';
-import { PLAY_PATH } from '@/lib/wo-haere/routes';
 import type { Metadata } from 'next';
 import Image from 'next/image';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import type { ReactNode } from 'react';
 
 const project = getProject('wo-haere');
 
@@ -15,69 +14,6 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/projects/wo-haere',
   },
-};
-
-const Section = ({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) => (
-  <section className="mt-16 flex flex-col gap-4">
-    <h2 className="text-2xl font-medium text-balance">{title}</h2>
-    {children}
-  </section>
-);
-
-const P = ({ children }: { children: ReactNode }) => (
-  <p className="text-pretty text-white/50">{children}</p>
-);
-
-const Table = ({ head, rows }: { head: string[]; rows: ReactNode[][] }) => (
-  <div className="overflow-x-auto">
-    <table className="w-full min-w-md border-collapse text-left text-sm">
-      <thead>
-        <tr className="border-b border-white/20">
-          {head.map(cell => (
-            <th key={cell} className="py-2 pr-4 font-medium">
-              {cell}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody className="text-white/50 tabular-nums">
-        {rows.map((row, i) => (
-          <tr key={i} className="border-b border-white/10">
-            {row.map((cell, j) => (
-              <td key={j} className="py-2 pr-4 align-top">
-                {cell}
-              </td>
-            ))}
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  </div>
-);
-
-const Shot = ({ index }: { index: number }) => {
-  const shot = project?.screenshots[index];
-  if (!shot) return null;
-  return (
-    <figure className="mt-2 flex flex-col gap-2">
-      <Image
-        src={shot.src}
-        width={shot.width}
-        height={shot.height}
-        alt={shot.alt}
-        className="w-full rounded-lg border border-white/20"
-      />
-      <figcaption className="text-sm text-pretty text-white/50">
-        {shot.alt}
-      </figcaption>
-    </figure>
-  );
 };
 
 export default function WoHaereCaseStudy() {
@@ -104,17 +40,11 @@ export default function WoHaereCaseStudy() {
         </P>
         <p className="text-sm text-white/50">{project.stack.join(' · ')}</p>
         {/*
-          A plain link, never a dynamic import of the game: pulling the map
+          Plain links, never a dynamic import of the game: pulling the map
           component in here would land ~250KB gz of maplibre on a page that is
-          mostly prose. prefetch={false} stops a hover doing the same thing.
+          mostly prose.
         */}
-        <Link
-          href={PLAY_PATH}
-          prefetch={false}
-          className="mt-2 inline-flex w-fit items-center gap-2 rounded-md border border-white/50 px-4 py-2 text-sm transition-colors hover:border-white hover:bg-white hover:text-black"
-        >
-          Play it →
-        </Link>
+        <ProjectLinks links={project.links} className="mt-2" />
       </header>
 
       <Image
@@ -170,7 +100,7 @@ export default function WoHaereCaseStudy() {
           zero results instead of an error — which reads exactly like
           &ldquo;abroad&rdquo;.
         </P>
-        <Shot index={1} />
+        <Shot shot={project.screenshots[0]} />
       </Section>
 
       <Section title="Three views">
@@ -198,7 +128,7 @@ export default function WoHaereCaseStudy() {
           for the world style — so readiness is tracked from the{' '}
           <code>style.load</code> event per map instance instead.
         </P>
-        <Shot index={2} />
+        <Shot shot={project.screenshots[1]} />
       </Section>
 
       <Section title="Three throw mechanics">
@@ -230,7 +160,7 @@ export default function WoHaereCaseStudy() {
           keeps the drag alive anywhere on screen while leaving the rest of the
           map free to pan.
         </P>
-        <Shot index={0} />
+        <Shot shot={project.screenshots[2]} />
       </Section>
 
       <Section title="How badly you miss">
@@ -238,14 +168,9 @@ export default function WoHaereCaseStudy() {
           Aiming only ever biases the throw — it never determines it, because
           nobody playing this can actually throw darts. The miss is calibrated
           from Tibshirani, Price &amp; Taylor,{' '}
-          <a
-            href="https://www.stat.cmu.edu/~ryantibs/papers/darts-jrss.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border-b border-white/50 transition-colors hover:border-white hover:text-white"
-          >
+          <A href="https://www.stat.cmu.edu/~ryantibs/papers/darts-jrss.pdf">
             <em>A statistician plays darts</em>
-          </a>{' '}
+          </A>{' '}
           (J. R. Statist. Soc. A, 2011), who model a throw as a 2-D Gaussian
           around the aim point and measured themselves over 100 throws at a
           board of radius 170 mm.
@@ -352,22 +277,14 @@ export default function WoHaereCaseStudy() {
           from a user gesture, and the pointer press that begins a drag is
           exactly that.
         </P>
-        <Shot index={3} />
+        <Shot shot={project.screenshots[3]} />
       </Section>
 
       <Section title="Copy">
         <P>
           Every user-facing string lives in one file, and every word is checked
-          against{' '}
-          <a
-            href="https://www.berndeutsch.ch"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="border-b border-white/50 transition-colors hover:border-white hover:text-white"
-          >
-            berndeutsch.ch
-          </a>{' '}
-          by a script that ships with the project.
+          against <A href="https://www.berndeutsch.ch">berndeutsch.ch</A> by a
+          script that ships with the project.
         </P>
         <P>
           Words that failed the check were replaced rather than shipped: it is{' '}
@@ -399,13 +316,7 @@ export default function WoHaereCaseStudy() {
       </Section>
 
       <div className="mt-16 border-t border-white/20 pt-8">
-        <Link
-          href={PLAY_PATH}
-          prefetch={false}
-          className="inline-flex w-fit items-center gap-2 rounded-md border border-white/50 px-4 py-2 text-sm transition-colors hover:border-white hover:bg-white hover:text-black"
-        >
-          Play it →
-        </Link>
+        <ProjectLinks links={project.links} />
       </div>
     </article>
   );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { projects } from '@/data/projects';
 import { SITE_LAST_MODIFIED, SITE_URL } from '@/lib/site';
 import type { MetadataRoute } from 'next';
 
@@ -15,12 +16,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.9,
     },
-    {
-      url: `${SITE_URL}/projects/wo-haere`,
+    // Case studies only. A project's own interactive route — /projects/wo-haere/play
+    // — is the thing itself rather than a document, so there is nothing stable on it
+    // to index. `as const` is load-bearing: the return-type annotation does not reach
+    // through a spread into .map(), so the literal would otherwise widen to string.
+    ...projects.map(project => ({
+      url: `${SITE_URL}/projects/${project.slug}`,
       lastModified: SITE_LAST_MODIFIED,
-      changeFrequency: 'monthly',
+      changeFrequency: 'monthly' as const,
       priority: 0.8,
-    },
+    })),
     {
       url: `${SITE_URL}/design`,
       lastModified: SITE_LAST_MODIFIED,

--- a/src/components/projects/Links.tsx
+++ b/src/components/projects/Links.tsx
@@ -1,0 +1,40 @@
+import type { ProjectLink } from '@/data/projects';
+import IconLink from '@/icons/Link';
+import Link from 'next/link';
+
+/**
+ * Never prefetches. An internal project link points at that project's interactive
+ * build, and /projects/wo-haere/play pulls ~250KB gz of maplibre onto a page that
+ * is mostly prose — a hover would do exactly what prefetch does. Absolute URLs
+ * ignore the prop, so it is unconditional rather than a field on ProjectLink.
+ */
+const ProjectLinks = ({
+  links,
+  className,
+}: {
+  links: ProjectLink[];
+  className?: string;
+}) => (
+  <ul className={`flex flex-wrap gap-2 ${className || ''}`}>
+    {links.map(({ label, href }) => {
+      const isExternal = href.startsWith('http');
+
+      return (
+        <li key={href}>
+          <Link
+            href={href}
+            prefetch={false}
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            className="inline-flex w-fit items-center gap-1.5 rounded-md border border-white/50 px-4 py-2 text-sm transition-colors hover:border-white hover:bg-white hover:text-black"
+          >
+            {label}
+            {isExternal ? <IconLink /> : <span aria-hidden="true">→</span>}
+          </Link>
+        </li>
+      );
+    })}
+  </ul>
+);
+
+export default ProjectLinks;

--- a/src/components/projects/Prose.tsx
+++ b/src/components/projects/Prose.tsx
@@ -1,0 +1,86 @@
+import type { Screenshot } from '@/data/projects';
+import Image from 'next/image';
+import type { ReactNode } from 'react';
+
+export const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) => (
+  <section className="mt-16 flex flex-col gap-4">
+    <h2 className="text-2xl font-medium text-balance">{title}</h2>
+    {children}
+  </section>
+);
+
+export const P = ({ children }: { children: ReactNode }) => (
+  <p className="text-pretty text-white/50">{children}</p>
+);
+
+/** Citations mid-sentence. Links that are calls to action belong in Project.links. */
+export const A = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="border-b border-white/50 transition-colors hover:border-white hover:text-white"
+  >
+    {children}
+  </a>
+);
+
+export const Table = ({
+  head,
+  rows,
+}: {
+  head: string[];
+  rows: ReactNode[][];
+}) => (
+  <div className="overflow-x-auto">
+    <table className="w-full min-w-md border-collapse text-left text-sm">
+      <thead>
+        <tr className="border-b border-white/20">
+          {head.map(cell => (
+            <th key={cell} className="py-2 pr-4 font-medium">
+              {cell}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody className="text-white/50 tabular-nums">
+        {rows.map((row, i) => (
+          <tr key={i} className="border-b border-white/10">
+            {row.map((cell, j) => (
+              <td key={j} className="py-2 pr-4 align-top">
+                {cell}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export const Shot = ({ shot }: { shot: Screenshot }) => (
+  <figure className="mt-2 flex flex-col gap-2">
+    <Image
+      src={shot.src}
+      width={shot.width}
+      height={shot.height}
+      alt={shot.alt}
+      className="w-full rounded-lg border border-white/20"
+    />
+    <figcaption className="text-sm text-pretty text-white/50">
+      {shot.alt}
+    </figcaption>
+  </figure>
+);

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,8 +1,15 @@
+import { PLAY_PATH } from '@/lib/wo-haere/routes';
+
 export interface Screenshot {
   src: string;
   width: number;
   height: number;
   alt: string;
+}
+
+export interface ProjectLink {
+  label: string;
+  href: string;
 }
 
 export interface Project {
@@ -11,19 +18,34 @@ export interface Project {
   tagline: string;
   year: number;
   stack: string[];
-  href: string;
-  links: { label: string; href: string }[];
+  links: ProjectLink[];
+  /** Landscape, please: the listing renders every cover full-width in one column. */
   cover: Screenshot;
   screenshots: Screenshot[];
 }
 
-const shot = (name: string, alt: string): Screenshot => ({
-  src: `/projects/wo-haere-${name}.webp`,
-  width: 1280,
-  height: 800,
-  alt,
-});
+/**
+ * Screenshots live at /public/projects/<slug>-<name>.webp and are served at their
+ * export size. Most shots in a project share one size, so it binds per project and
+ * is overridden only for the odd one out — a menu bar popover is portrait where a
+ * map is landscape.
+ */
+const shots =
+  (slug: string, width: number, height: number) =>
+  (
+    name: string,
+    alt: string,
+    size?: { width: number; height: number },
+  ): Screenshot => ({
+    src: `/projects/${slug}-${name}.webp`,
+    width: size?.width ?? width,
+    height: size?.height ?? height,
+    alt,
+  });
 
+const woHaere = shots('wo-haere', 1280, 800);
+
+/** Array order is listing order — curated, not chronological. */
 export const projects: Project[] = [
   {
     slug: 'wo-haere',
@@ -32,26 +54,26 @@ export const projects: Project[] = [
       'Throw a dart at a map of Switzerland and let it decide where to go next.',
     year: 2026,
     stack: ['Next.js', 'MapLibre GL', 'swisstopo', 'Web Audio', 'Tailwind CSS'],
-    href: '/projects/wo-haere',
-    links: [{ label: 'Play it', href: '/projects/wo-haere/play' }],
-    cover: shot(
+    links: [{ label: 'Play it', href: PLAY_PATH }],
+    cover: woHaere(
       'charte',
       'The swisstopo Landeskarte with the dart ready to throw',
     ),
+    // Ordered as the case study reads them, so the indices run down the page.
     screenshots: [
-      shot(
-        'aim',
-        'The aim overlay: a dashed flight path, a crosshair on the predicted landing spot and a dashed one-sigma ring, at 61% force',
-      ),
-      shot(
+      woHaere(
         'result',
         'The result card after a throw landed in Val Bavona, Ticino, 1819 m above sea level and 108 km from Bern',
       ),
-      shot(
+      woHaere(
         'globe',
         'The Wäutchugele view: a MapLibre globe projection with the landed dart marked over Switzerland',
       ),
-      shot(
+      woHaere(
+        'aim',
+        'The aim overlay: a dashed flight path, a crosshair on the predicted landing spot and a dashed one-sigma ring, at 61% force',
+      ),
+      woHaere(
         'panel',
         'The settings panel showing the view and throw-style pickers, the canton stamp card and the throw log',
       ),

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,3 +1,3 @@
 export const SITE_URL = 'https://olivierwinkler.ch';
 
-export const SITE_LAST_MODIFIED = '2026-08-11';
+export const SITE_LAST_MODIFIED = '2026-08-16';


### PR DESCRIPTION
## Summary

`src/data/projects.ts` was written for exactly one project and showed it in five places. Two more are coming — MacVitals (#380) and InputMetrics (#381), both macOS menu bar apps — and neither could have been added without this first. User-visibly this changes nothing except one flagged pixel.

Closes #379.

## Changes

**The data layer**
- Replace `shot()` — which hardcoded both the `wo-haere-` filename prefix and 1280×800 — with a curried `shots(slug, width, height)` bound once per project, plus a per-image size override. The override earns its place immediately: a menu bar popover is portrait where a map is landscape. wo-häre migrates by renaming one identifier at five call sites, no argument changes.
- Delete `Project.href`. It was a stored field that is a pure function of `slug`, with exactly one reader; the listing now derives it. No `projectPath()` helper — two template literals in two files does not earn one.
- Point wo-häre's link at `PLAY_PATH` from `@/lib/wo-haere/routes` instead of restating the path. That module is dependency-free by design, so a data → routes edge is safe and one-way.
- Reorder `screenshots` to the order the case study reads them, so the indices now run 0–3 down the page instead of 1, 2, 0, 3.

**Two new components**
- `components/projects/Prose.tsx` — `Section`, `P` and `Table` move out of the case study verbatim, plus a new `A` for prose citations, whose class string was already duplicated twice inside the single page that exists. `Shot` takes the `Screenshot` rather than an index, since it can no longer close over a module-scope `project`; its `if (!shot) return null` guard disappears because with a required prop it is unreachable.
- `components/projects/Links.tsx` — renders `Project.links`, which was declared and populated but read by nothing (`rg '\.links'` found only the type and the literal). Deliberately not `CustomLink`: it has no `prefetch` prop, and `prefetch={false}` is the load-bearing half of the maplibre constraint — reusing it would mean widening its interface for one caller and fighting its text-link styling with `!` overrides. Deliberately not on the listing either: that card is one big `<Link>`, and nesting anchors is invalid HTML.

**Listing and sitemap**
- `priority={index === 0}` on the listing covers. Unconditional `priority` was fine at n=1; at n=3 all three compete for the same connection and only the first is above the fold.
- `sitemap.ts` maps over `projects` for the case studies, keeping home, `/projects` and `/design` static. The previous hardcoded list was where a fourth project would have been forgotten, and the deliberate absence of `/projects/wo-haere/play` — the game is not a document — was invisible to a reader; it is now a comment. `changeFrequency: 'monthly' as const` is required, because the return-type annotation does not contextually type through a spread into `.map()`.
- Bump `SITE_LAST_MODIFIED`.

## Additional Notes

**One incidental fix, surfaced by this work rather than planned.** 3070bac added `.prettierignore` to stop prettier reflowing `pnpm-lock.yaml`, but the script still passed `--ignore-path .gitignore`. That flag *replaces* the default ignore-file list rather than adding to it, so `.prettierignore` was never read and the lockfile kept being reformatted — 2,688 lines on the run I did here, and a guaranteed conflict with every dependabot PR. Prettier 3 reads both files by default, so dropping the flag is the whole fix. Confirmed afterwards that the lockfile is untouched and `public/` is still skipped.

**Verified against a running dev server, not by reasoning.**
- All four routes return 200; `/sitemap.xml` lists the expected URLs with `/projects/wo-haere/play` absent.
- The wo-häre case study renders exactly two play buttons and both prose citations keep `target="_blank" rel="noopener noreferrer"`.
- The listing emits `loading="lazy"` on the non-first covers only, confirming the `priority` change took effect.
- `pnpm build` typechecks clean.

**One flagged pixel delta.** Moving the `→` into its own `aria-hidden` span means the existing `gap-2` starts applying, so the label-to-arrow gap would have gone 0.25rem → 0.5rem. Set to `gap-1.5` to keep it visually identical. The `aria-hidden` is a small a11y win either way — the arrow was previously announced.

**Known and untouched:** `pnpm lint` is still broken exactly as #358 describes (`next lint` no longer exists in Next 16). Not caused by this branch and out of scope for it.
