### PR TITLE
fix(seo): set canonical per page instead of root default

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -1,4 +1,11 @@
 import CustomLink from '@/components/Link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: '/',
+  },
+};
 
 export default function Home() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,9 +17,6 @@ export const metadata: Metadata = {
     template: '%s | Olivier Winkler',
   },
   description,
-  alternates: {
-    canonical: '/',
-  },
   openGraph: {
     type: 'website',
     url: SITE_URL,


### PR DESCRIPTION
## Summary
Every page inherited `alternates.canonical: '/'` from the root layout via Next.js metadata merging, telling search engines the homepage was canonical for every URL and suppressing indexing of the other pages.

## Changes
- Remove the inherited `alternates.canonical: '/'` default from `src/app/layout.tsx` so a missing canonical fails loudly (no canonical) rather than silently pointing at the homepage.
- Add the homepage's own `alternates.canonical: '/'` in `src/app/(site)/page.tsx`.

## Additional Notes
Every other route (`/design`, `/projects`, `/projects/wo-haere`, `.../play`) already declares its own canonical. Verified with `pnpm build && pnpm start` that each route now reports its own canonical URL. Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)