### PR TITLE
fix(wo-haere): end Aaflug dive on Charte's framing

### DIFF
--- a/src/components/wo-haere/Wandcharte.tsx
+++ b/src/components/wo-haere/Wandcharte.tsx
@@ -274,14 +274,20 @@ export default function Wandcharte({
 
     // Aaflug: hang on the globe for a moment, then dive into Switzerland.
     // Crossing the raster layer's minzoom reveals the Landeskarte on the way.
+    // End on Charte's framing (derived from CH_FIT, so it tracks the viewport
+    // aspect ratio) rather than a fixed zoom — a fixed zoom settles wide enough
+    // that the swisstopo coverage edge creeps into frame as a cream band.
+    const ziu = map.cameraForBounds(CH_FIT, { padding: 24 });
+    const center = ziu?.center ?? ([8.2, 46.8] as [number, number]);
+    const zoom = ziu?.zoom ?? 7.2;
     if (reduced) {
-      map.jumpTo({ center: [8.2, 46.8], zoom: 7.2 });
+      map.jumpTo({ center, zoom });
       return;
     }
     map.jumpTo({ center: [8.2, 46.8], zoom: 1.8 });
     map.flyTo({
-      center: [8.2, 46.8],
-      zoom: 7.2,
+      center,
+      zoom,
       duration: 4200,
       essential: true,
     });


### PR DESCRIPTION
## Summary
When the Aaflug view finished diving from the globe into Switzerland, the camera settled at a fixed zoom that was too wide, spilling past the swisstopo WMTS tile source bounds and showing a cream band along the left and top edges.

## Changes
- Derive the Aaflug dive's end camera from `CH_FIT` via `map.cameraForBounds(..., { padding: 24 })`, matching the Charte view's framing so Switzerland fills the frame within tile coverage.
- Apply the derived `center`/`zoom` to both the animated `flyTo` and the reduced-motion `jumpTo`, with the previous `[8.2, 46.8]`/`7.2` values kept as fallbacks.

## Additional Notes
Because the camera is now computed from the bounds instead of a fixed zoom, it adapts to any viewport aspect ratio (tall phone vs. wide desktop). Worth a visual pass in the app to confirm the band is gone.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)