### PR TITLE
fix(wo-haere): drop maximumScale to restore pinch-zoom

### DIFF
--- a/src/app/(fullscreen)/projects/wo-haere/play/page.tsx
+++ b/src/app/(fullscreen)/projects/wo-haere/play/page.tsx
@@ -11,8 +11,6 @@ export const viewport: Viewport = {
   themeColor: '#1c1917',
   width: 'device-width',
   initialScale: 1,
-  // The map fills the viewport, so pinch-zooming the page would fight panning.
-  maximumScale: 1,
 };
 
 /**


### PR DESCRIPTION
## Summary
The play route blocked pinch-zoom document-wide via `maximumScale: 1`, which fails WCAG 2.1 SC 1.4.4 (Resize Text) and is ignored by iOS Safari anyway — leaving it costly where it works and useless where accidental pinch is most likely.

## Changes
- Remove `maximumScale: 1` (and its comment) from the `viewport` export in `src/app/(fullscreen)/projects/wo-haere/play/page.tsx`.

## Additional Notes
Map-gesture handling is unchanged: MapLibre still owns gestures over the canvas and the drag handle keeps its local `touch-none`. A scoped `touch-action` on the map container is deferred until pinch on the surrounding chrome proves to be a real nuisance on a touch device.

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)