### PR TITLE
chore(ci): add build gate workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build


### PR DESCRIPTION
## Summary
Dependencies land weekly via dependabot with nothing verifying the site still builds. This adds a minimal CI build gate so a breaking runtime dependency is caught before merge instead of on the deployed site.

## Changes
- Add `.github/workflows/build.yml` running on `pull_request` and pushes to `main`: checkout, pnpm + Node 22 with a pnpm cache, `pnpm install --frozen-lockfile`, then `pnpm build`.
- Add a `concurrency` group to cancel superseded runs on the same ref.

## Additional Notes
- `pnpm lint` is intentionally omitted until the lint script is runnable, and no dependabot `ignore` rule was added — both are follow-ups the issue flags as optional.
- Verified `pnpm build` passes locally with no env vars required.

Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)