### PR TITLE
fix(wo-haere): keep swisstopo attribution visible behind panel

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,3 +101,10 @@ body {
 .maplibregl-ctrl-bottom-right {
   margin-bottom: env(safe-area-inset-bottom);
 }
+
+/* When the settings panel is open it covers the bottom-right corner, hiding the
+   legally required attribution. Shift the control left by the panel width so it
+   stays visible. Panel width mirrors WoHaere's w-[min(20rem,100vw)]. */
+[data-panee-offe] .maplibregl-ctrl-bottom-right {
+  margin-right: min(20rem, 100vw);
+}

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -221,6 +221,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
     // so the override lives here.
     <main
       lang="gsw-CH"
+      data-panee-offe={paneeOffe || undefined}
       className="relative h-dvh w-full overflow-hidden bg-stone-800"
     >
       <div className="absolute inset-0">


### PR DESCRIPTION
## Summary
The settings panel opens over the map's bottom-right corner, where MapLibre renders the legally required `© swisstopo` attribution — leaving it as dark text on the panel's dark background, effectively invisible.

## Changes
- Add `data-panee-offe` on `WoHaere`'s `<main>` reflecting the panel-open state.
- Shift `.maplibregl-ctrl-bottom-right` left by the panel width (`min(20rem, 100vw)`) via that attribute in `globals.css`, so the attribution stays over the map and legible whenever the panel is open.

## Additional Notes
No animation added — the panel toggles instantly and layout properties aren't animated. Closes #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)