### PR TITLE
fix(wo-haere): snap coordinates to a grid before calling swisstopo

### DIFF
--- a/src/lib/wo-haere/geo/ch.ts
+++ b/src/lib/wo-haere/geo/ch.ts
@@ -23,6 +23,18 @@ export function isInChBbox({ lat, lon }: LatLon): boolean {
   );
 }
 
+/**
+ * Grid resolution for coordinates sent upstream and shared in links.
+ * 4 decimals is ~7-11m at Swiss latitudes — far below the app's resolution,
+ * and enough to collapse adjacent throws onto one cache key.
+ */
+export const GRID_DECIMALS = 4;
+
+export function snapToGrid({ lat, lon }: LatLon): LatLon {
+  const f = 10 ** GRID_DECIMALS;
+  return { lat: Math.round(lat * f) / f, lon: Math.round(lon * f) / f };
+}
+
 const EARTH_RADIUS_KM = 6371;
 const toRad = (deg: number) => (deg * Math.PI) / 180;
 const toDeg = (rad: number) => (rad * 180) / Math.PI;

--- a/src/lib/wo-haere/geo/resolveHit.ts
+++ b/src/lib/wo-haere/geo/resolveHit.ts
@@ -5,6 +5,7 @@ import {
   himmurichtig,
   isInChBbox,
   isWasser,
+  snapToGrid,
   type LatLon,
 } from '@/lib/wo-haere/geo/ch';
 
@@ -92,8 +93,13 @@ async function fetchHoechi(lon: number, lat: number): Promise<number | null> {
  *   - a current record        -> a real Swiss municipality (or a Swiss lake)
  *   - historical records only -> border water such as the French part of Léman
  *   - nothing at all          -> abroad
+ *
+ * The point is snapped to the grid first: this is the only place the app talks
+ * to swisstopo, so snapping here keeps every upstream URL cache-aligned and
+ * stops a caller from walking coordinates to generate unbounded requests.
  */
-export async function resolveHit(point: LatLon): Promise<Wurf> {
+export async function resolveHit(rawPoint: LatLon): Promise<Wurf> {
+  const point = snapToGrid(rawPoint);
   const { lat, lon } = point;
 
   if (!isInChBbox(point)) {

--- a/src/lib/wo-haere/wurfParam.ts
+++ b/src/lib/wo-haere/wurfParam.ts
@@ -1,4 +1,4 @@
-import type { LatLon } from '@/lib/wo-haere/geo/ch';
+import { GRID_DECIMALS, type LatLon } from '@/lib/wo-haere/geo/ch';
 
 /**
  * `?wurf=46.6200,8.0418` — a shared throw. Accepts the raw value from either a
@@ -19,7 +19,11 @@ export function parseWurf(
   return { lat, lon };
 }
 
-/** The canonical `lat,lon` form used in shared links and OG image URLs. */
+/**
+ * The canonical `lat,lon` form used in shared links and OG image URLs. Kept on
+ * the same grid as `snapToGrid`, so a shared throw hits the same upstream cache
+ * key as the original.
+ */
 export function formatWurf({ lat, lon }: LatLon): string {
-  return `${lat.toFixed(4)},${lon.toFixed(4)}`;
+  return `${lat.toFixed(GRID_DECIMALS)},${lon.toFixed(GRID_DECIMALS)}`;
 }


### PR DESCRIPTION
Closes #372

## Changes

`/api/wo-haere/wurf` forwarded whatever coordinate the client sent. The client sends `map.unproject()` output verbatim — full double precision — so effectively **every throw was a unique fetch cache key and a fresh upstream request**, despite `resolveHit` caching hard (`revalidate: 2592000`). Walking coordinates generated unbounded calls to swisstopo's free API, all attributed to this site. With #364 about to link the app publicly, the failure mode is our egress IP getting rate-limited, breaking the game for real visitors with no obvious cause.

Coordinates are now snapped to 4 decimals (~7–11m at Swiss latitudes, far below the app's resolution) before the upstream call, collapsing adjacent throws onto one cache key.

Three commits, each standalone:

1. `feat` — `GRID_DECIMALS` + `snapToGrid` in `geo/ch.ts`, pure helper, no caller
2. `fix` — apply it in `resolveHit`
3. `refactor` — tie `formatWurf` to `GRID_DECIMALS` instead of a literal `4`

Snapping lives in `resolveHit` rather than the route handler on purpose: it's the only place the app talks to swisstopo, so it covers **both** callers — the POST route and `/api/wo-haere/og`, a GET that's robots-allowed and was equally unthrottled. It also grid-aligns the `identify` `mapExtent` and the `height` lookup, so the whole upstream URL becomes cache-aligned.

4 decimals is what `formatWurf` already emitted, so a shared link, its OG image, and the original throw now converge on the *same* cache key instead of three different ones.

## Verification

`pnpm build`, `pnpm lint`, `prettier --check` all pass; each commit typechecks independently.

Two distinct inputs (`46.94801234,7.44741234` and `46.94802345,7.44742345`) return identical `lat:46.948, lon:7.4474, gmeind:"Bern"`. That the cache genuinely collapses was measured, not assumed:

| request | time |
|---|---|
| cold cell `46.5,8.0` | 1.166s |
| same cell, jittered input | **0.007s** |
| same cell, jittered the other way | **0.011s** |
| adjacent *different* cell `46.501,8.001` | 0.865s |

~150x faster for jittered inputs (no upstream call), while a neighbouring cell is cold again — cache-key collapse, not server warm-up.

Regressions checked: Paris short-circuits to `{art:'dernaebe', grund:'usland'}` with no upstream call; the three validation errors still return their original 400s; the OG card and the play-page replay both render correctly.

## Additional notes

- **The issue's fix #2 was already implemented** — `resolveHit` has short-circuited on `!isInChBbox(point)` before any fetch for a while. Nothing to do there. The issue's paths are also stale (`/api/wo-haere/wurf`, `src/lib/wo-haere/geo/ch.ts`).
- **Fix #3 (per-IP rate limit) is deliberately not in code.** The issue expects 1 and 2 to be enough ("worth measuring first"). If traffic after #364 shows enumeration, configure it in the Vercel dashboard under Firewall -> Rate Limiting scoped to `/api/wo-haere/*` — zero deps, and it covers the GET OG route too.
- Unrelated pre-existing quirk found while tracing this, not touched: `WoHaere.tsx` computes `noechschtsZiu` from the client's unsnapped `ort` while the OG route uses the parsed 4dp param, so a throw on a nearest-target boundary could name a different target in the card than the player saw. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)