### PR TITLE
refactor(wo-haere): route stacking through a z-index scale, and fix two layering bugs

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,6 +82,18 @@ body {
   background: var(--background);
 }
 
+/* Wo häre? — the one place stacking order is decided. Every z-index in the
+   feature reads from here; nothing sets a bare z-* utility.
+   `pfyl` sits below `panee` deliberately: a dart thrown with the settings
+   panel open flies under it, not across it. */
+:root {
+  --z-steuerig: 10; /* Zieuhilf, the HUD header, the bottom controls */
+  --z-pfyl: 20; /* the dart in flight */
+  --z-panee: 30; /* the settings panel */
+  --z-vorhang: 40; /* Wurfbuech's dialog backdrop */
+  --z-dialog: 50; /* Wurfbuech's dialog */
+}
+
 /* Wo häre? — a landed dart, left behind on the map by an earlier throw. */
 .pfyl-loch {
   width: 0.55rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,7 @@ body {
    `pfyl` sits below `panee` deliberately: a dart thrown with the settings
    panel open flies under it, not across it. */
 :root {
+  --z-charte: 0; /* Wandcharte — the map, and MapLibre's own controls */
   --z-steuerig: 10; /* Zieuhilf, the HUD header, the bottom controls */
   --z-pfyl: 20; /* the dart in flight */
   --z-panee: 30; /* the settings panel */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,14 +85,17 @@ body {
 /* Wo häre? — the one place stacking order is decided. Every z-index in the
    feature reads from here; nothing sets a bare z-* utility.
    `pfyl` sits below `panee` deliberately: a dart thrown with the settings
-   panel open flies under it, not across it. */
+   panel open flies under it, not across it. `zue` sits above `panee` just as
+   deliberately: it is the panel's own close button, so the panel must not
+   cover it. The rest of the HUD stays below, where the panel can. */
 :root {
   --z-charte: 0; /* Wandcharte — the map, and MapLibre's own controls */
-  --z-steuerig: 10; /* Zieuhilf, the HUD header, the bottom controls */
+  --z-steuerig: 10; /* Zieuhilf, the title card, the bottom controls */
   --z-pfyl: 20; /* the dart in flight */
   --z-panee: 30; /* the settings panel */
-  --z-vorhang: 40; /* Wurfbuech's dialog backdrop */
-  --z-dialog: 50; /* Wurfbuech's dialog */
+  --z-zue: 40; /* the ☰/✕ toggle that opens and closes the panel */
+  --z-vorhang: 50; /* Wurfbuech's dialog backdrop */
+  --z-dialog: 60; /* Wurfbuech's dialog */
 }
 
 /* Wo häre? — a landed dart, left behind on the map by an earlier throw. */

--- a/src/components/wo-haere/Pfyl.tsx
+++ b/src/components/wo-haere/Pfyl.tsx
@@ -104,7 +104,7 @@ export default function Pfyl({ ziel, sorte, stil, onGladet }: PfylProps) {
 
   return (
     <motion.div
-      className="pointer-events-none absolute top-0 left-0 z-30 will-change-transform"
+      className="pointer-events-none absolute top-0 left-0 z-(--z-pfyl) will-change-transform"
       initial={
         reduced
           ? { opacity: 0, x: ziel.x, y: ziel.y, scale: 1, rotate: 0 }

--- a/src/components/wo-haere/Resultatcharte.tsx
+++ b/src/components/wo-haere/Resultatcharte.tsx
@@ -44,7 +44,7 @@ export default function Resultatcharte({
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{ duration: reduced ? 0.12 : 0.2, ease: 'easeOut' }}
       className={cn(
-        'w-full max-w-md rounded-2xl border border-stone-300/80 bg-white/95 p-5 shadow-xl',
+        'pointer-events-auto w-full max-w-md rounded-2xl border border-stone-300/80 bg-white/95 p-5 shadow-xl',
         'backdrop-blur-none dark:border-stone-700/80 dark:bg-stone-900/95',
       )}
     >

--- a/src/components/wo-haere/Wandcharte.tsx
+++ b/src/components/wo-haere/Wandcharte.tsx
@@ -313,5 +313,10 @@ export default function Wandcharte({
   // Sized explicitly rather than with `absolute inset-0`: maplibre's own
   // stylesheet forces `position: relative` on .maplibregl-map, which would
   // override the utility class and collapse the container to zero height.
-  return <div ref={containerRef} className="size-full" />;
+  //
+  // That same forced `position` is what makes --z-charte bite: it pins the map
+  // to the base layer of the scale and, being a stacking context, boxes
+  // maplibre's own control z-indexes in here rather than letting them compete
+  // with the app chrome outside.
+  return <div ref={containerRef} className="z-(--z-charte) size-full" />;
 }

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -251,7 +251,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       </div>
 
       <header
-        className="pointer-events-none absolute inset-x-0 top-0 z-(--z-steuerig) flex items-start justify-between gap-3 p-4"
+        className="pointer-events-none absolute inset-x-0 top-0 z-(--z-steuerig) flex items-start p-4"
         style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}
       >
         <div className="pointer-events-auto rounded-xl bg-white/90 px-3 py-2 shadow-lg dark:bg-stone-900/90">
@@ -269,7 +269,15 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
             ← {AKTIONE.zrugg}
           </Link>
         </div>
+      </header>
 
+      {/* Lives outside the header, on its own layer: this is the panel's own
+          close button, so the panel has to stay off it. The rest of the header
+          keeps the layer the panel is free to cover. */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 z-(--z-zue) flex justify-end p-4"
+        style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}
+      >
         <button
           type="button"
           aria-label={YTEXT.titu}
@@ -279,7 +287,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
         >
           {paneeOffe ? '✕' : '☰'}
         </button>
-      </header>
+      </div>
 
       {paneeOffe && (
         <aside

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -322,13 +322,13 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       )}
 
       <div
-        className="absolute inset-x-0 bottom-0 z-(--z-steuerig) flex flex-col items-center gap-3 p-4"
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-(--z-steuerig) flex flex-col items-center gap-3 p-4"
         style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
       >
         {fähler && (
           <div
             role="alert"
-            className="w-full max-w-md rounded-xl border border-red-300 bg-white/95 p-4 shadow-xl dark:border-red-800 dark:bg-stone-900/95"
+            className="pointer-events-auto w-full max-w-md rounded-xl border border-red-300 bg-white/95 p-4 shadow-xl dark:border-red-800 dark:bg-stone-900/95"
           >
             <h2 className="font-bold text-red-700 dark:text-red-500">
               {FAEHLER.titu}

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -251,7 +251,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       </div>
 
       <header
-        className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-start justify-between gap-3 p-4"
+        className="pointer-events-none absolute inset-x-0 top-0 z-(--z-steuerig) flex items-start justify-between gap-3 p-4"
         style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}
       >
         <div className="pointer-events-auto rounded-xl bg-white/90 px-3 py-2 shadow-lg dark:bg-stone-900/90">
@@ -284,7 +284,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       {paneeOffe && (
         <aside
           className={cn(
-            'absolute top-0 right-0 z-30 flex h-dvh w-[min(20rem,100vw)] flex-col gap-5',
+            'absolute top-0 right-0 z-(--z-panee) flex h-dvh w-[min(20rem,100vw)] flex-col gap-5',
             'overflow-y-auto border-l border-stone-300 bg-white/97 p-4 shadow-2xl',
             'dark:border-stone-700 dark:bg-stone-900/97',
           )}
@@ -314,7 +314,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       )}
 
       <div
-        className="absolute inset-x-0 bottom-0 z-20 flex flex-col items-center gap-3 p-4"
+        className="absolute inset-x-0 bottom-0 z-(--z-steuerig) flex flex-col items-center gap-3 p-4"
         style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
       >
         {fähler && (

--- a/src/components/wo-haere/Wurfbuech.tsx
+++ b/src/components/wo-haere/Wurfbuech.tsx
@@ -69,10 +69,10 @@ export default function Wurfbuech({
               {TEXT.leere}
             </AlertDialog.Trigger>
             <AlertDialog.Portal>
-              <AlertDialog.Backdrop className="fixed inset-0 z-40 bg-black/40" />
+              <AlertDialog.Backdrop className="fixed inset-0 z-(--z-vorhang) bg-black/40" />
               <AlertDialog.Popup
                 className={cn(
-                  'fixed top-1/2 left-1/2 z-50 w-[min(24rem,calc(100vw-2rem))]',
+                  'fixed top-1/2 left-1/2 z-(--z-dialog) w-[min(24rem,calc(100vw-2rem))]',
                   '-translate-x-1/2 -translate-y-1/2 rounded-2xl bg-white p-5 shadow-2xl',
                   'dark:bg-stone-900',
                 )}

--- a/src/components/wo-haere/Wurfsteuerig.tsx
+++ b/src/components/wo-haere/Wurfsteuerig.tsx
@@ -160,7 +160,7 @@ export default function Wurfsteuerig({
 
   if (wurfart === 'tipp') {
     return (
-      <div className="flex flex-col items-center gap-2">
+      <div className="pointer-events-auto flex flex-col items-center gap-2">
         <button
           type="button"
           disabled={gsperrt}
@@ -187,7 +187,7 @@ export default function Wurfsteuerig({
     wurfart === 'schlüder' ? WURFARTE.schlüder.hiuf : WURFARTE.zieh.hiuf;
 
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className="pointer-events-auto flex flex-col items-center gap-2">
       {/* Grab the dart and drag: direction aims, length is the force. Pointer
           capture means the drag continues anywhere on screen, so the map keeps
           its own panning outside this handle. */}

--- a/src/components/wo-haere/Zieuhilf.tsx
+++ b/src/components/wo-haere/Zieuhilf.tsx
@@ -33,7 +33,7 @@ export default function Zieuhilf({
 
   return (
     <svg
-      className="pointer-events-none absolute inset-0 z-20 size-full"
+      className="pointer-events-none absolute inset-0 z-(--z-steuerig) size-full"
       aria-hidden="true"
     >
       {/* Honest about the odds: roughly two thirds of throws land inside this


### PR DESCRIPTION
Closes #370

## Changes

The seven stacking decisions in `wo-haere` were bare Tailwind literals with no shared scale. Two collided — the dart in flight and the settings panel were both `z-30` in the same stacking context, so paint order fell out of DOM position alone.

The scale now lives in one place:

```css
:root {
  --z-charte: 0; /* Wandcharte — the map, and MapLibre's own controls */
  --z-steuerig: 10; /* Zieuhilf, the title card, the bottom controls */
  --z-pfyl: 20; /* the dart in flight */
  --z-panee: 30; /* the settings panel */
  --z-zue: 40; /* the ☰/✕ toggle that opens and closes the panel */
  --z-vorhang: 50; /* Wurfbuech's dialog backdrop */
  --z-dialog: 60; /* Wurfbuech's dialog */
}
```

Four commits, each independently building and lint-clean:

1. **`refactor: route stacking through a z-index scale`** — declares the scale, points the seven existing sites at it. Zero visual change.
2. **`refactor: pin the map to the base stacking layer`** — gives `Wandcharte`'s container `--z-charte`, so the scale has a real base instead of a token nothing consumes.
3. **`fix: keep the panel's close button above the panel`** — see below.
4. **`fix: let pointer events through the bottom control bar`** — see below.

## The two bugs

Both were **pre-existing on `main`**, surfaced while verifying this PR — not regressions. Confirmed by running the same hit-test against both branches and getting byte-identical results, plus a dark-mode screenshot diff of the open panel at **0 different / 921600 pixels**.

**The panel's close button was unreachable.** The ☰/✕ toggle lives in the top HUD, which sat *below* the panel. Opening the panel painted its 97%-opaque background over the button — it dimmed to near invisible and stopped taking clicks, leaving no way to close the panel but a reload.

Fixed by moving the toggle out of the header onto `--z-zue`, above `--z-panee`. **Only the toggle rises.** The title card stays on `--z-steuerig`, because raising the whole header floated the card over the panel's first label at narrow widths — caught at 390px during verification, after an initial attempt did exactly that. The panel already reserved a 4.5rem top strip for this button, so the layering was the part that had been missing.

**MapLibre's attribution didn't respond to hover or click.** The bottom control container is `absolute inset-x-0`, but unlike `<header>` it never got `pointer-events-none`, so its transparent margins swallowed every event aimed at the `© swisstopo ⓘ` control in the corner. Fixed with the same `pointer-events-none` / `pointer-events-auto` pattern the top HUD already uses.

## Additional Notes

**The issue's premise was wrong.** #370 says `globals.css` declares a `--z-*` scale that nothing uses. That block does not exist and never has — `git log -S '--z-pfyl' --all` returns nothing. This PR *introduces* the scale rather than un-orphaning one. The issue's line numbers are also stale.

**Tailwind v4 has no z-index theme namespace**, so `--z-*` inside `@theme` would generate nothing. The tokens live in `:root`, consumed via the `z-(--var)` shorthand.

**On the dart/panel ordering:** the issue contradicts itself — it says the current outcome "happens to land the right way" (DOM order puts the panel *over* the dart) but then prescribes giving `--z-pfyl` a value *above* `--z-panee`, which would flip that. This PR follows the former, so a throw taken with the panel open flies under it exactly as on `main`.

**On the new stacking context:** MapLibre forces `position: relative` on `.maplibregl-map`, so `z-index: 0` makes it a stacking context now containing MapLibre's own values — only `.maplibregl-ctrl-*` at `2` (below `--z-steuerig` either way) and `.maplibregl-cooperative-gesture-screen` at `99999`, which never renders since the map is built without `cooperativeGestures`.

`Zue` and `Chopf` are both already in the app's own Berndeutsch copy (`bern.ts:25`, `ziu.ts:89`), so the token name needs no new vocabulary. `pnpm vocab:wo-haere` couldn't be run to confirm — it needs network access.

Scope stays in `wo-haere`. `Header.tsx`, `Dock.tsx` and `Footer.tsx` live under `SiteChrome` in `(site)` while `wo-haere/play` is under `(fullscreen)`, so they never coexist.

## Verification

`pnpm lint`, `pnpm build` and `prettier --check` pass on **each commit independently**. Built CSS emits all seven utilities and all seven `:root` values; every token has exactly one consumer.

Drove the real page and read `getComputedStyle().zIndex` off each live element — map `0`, HUD/controls/aim overlay `10`, dart `20`, panel `30`, toggle `40`, backdrop `50`, dialog `60`.

Hit-tested with the panel open, at 1280×720 and 390×844:

| Target | Before | After |
| --- | --- | --- |
| ☰/✕ toggle | ❌ covered by panel | ✅ clickable |
| MapLibre attribution | ❌ covered by control bar | ✅ clickable |
| Throw control | ✅ | ✅ still clickable |
| Title card / ← Zrügg | covered by panel at 390px | ✅ unchanged |

Also confirmed the dialog still layers above everything with its buttons reachable, and that a throw taken with the panel open still flies under it.

Mobile pixel diff vs `main` with the panel open: **89 of 329160 pixels** — the ✕ glyph going from dimmed to crisp, which is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)