### PR TITLE
feat(analytics): add GTM delivery layer and typed event contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Analytics — leave unset to no-op the whole layer (track() logs to the console).
+# GA4 is configured inside the GTM container, so only the GTM id loads a script.
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+
+# Server-only, for the GA4 Measurement Protocol (a later analytics layer).
+GA4_API_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ npm-debug.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*
+!.env.example

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.7.0",
+    "@next/third-parties": "16.3.1",
     "@vercel/analytics": "2.0.1",
     "@vercel/speed-insights": "2.0.0",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@base-ui/react':
         specifier: 1.7.0
         version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@next/third-parties':
+        specifier: 16.3.1
+        version: 16.3.1(next@16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/analytics':
         specifier: 2.0.1
         version: 2.0.1(next@16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -562,6 +565,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@16.3.1':
+    resolution: {integrity: sha512-OyIUIohaQ8AkD/8Ew0yPTaxcoOwobIgBjvNnhajgJ2IWPuSjFHfKYAFmFjYmL5Jwrf2qJDWubadhPqPbFhrDNg==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2714,6 +2723,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -3437,6 +3449,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
+
+  '@next/third-parties@16.3.1(next@16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      next: 16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5894,6 +5912,8 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  third-party-capital@1.0.20: {}
 
   tinybench@2.9.0: {}
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import AnalyticsScripts from '@/components/analytics/AnalyticsScripts';
+import PageViewTracker from '@/components/analytics/PageViewTracker';
 import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -91,12 +93,14 @@ export default function RootLayout({
 
   return (
     <html lang="en">
+      <AnalyticsScripts />
       <body className={`${GeistSans.variable} ${GeistMono.variable} font-sans`}>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         {children}
+        <PageViewTracker />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/analytics/AnalyticsScripts.tsx
+++ b/src/components/analytics/AnalyticsScripts.tsx
@@ -1,6 +1,7 @@
 import ConsentBootstrap from '@/components/analytics/ConsentBootstrap';
 import { GTM_ID, isAnalyticsEnabled } from '@/lib/analytics/config';
 import { GoogleTagManager } from '@next/third-parties/google';
+import { Fragment } from 'react';
 
 /**
  * The delivery path: the Consent Mode defaults followed by the GTM container.
@@ -13,10 +14,10 @@ const AnalyticsScripts = () => {
   if (!isAnalyticsEnabled) return null;
 
   return (
-    <>
+    <Fragment>
       <ConsentBootstrap />
       <GoogleTagManager gtmId={GTM_ID} />
-    </>
+    </Fragment>
   );
 };
 

--- a/src/components/analytics/AnalyticsScripts.tsx
+++ b/src/components/analytics/AnalyticsScripts.tsx
@@ -1,0 +1,23 @@
+import ConsentBootstrap from '@/components/analytics/ConsentBootstrap';
+import { GTM_ID, isAnalyticsEnabled } from '@/lib/analytics/config';
+import { GoogleTagManager } from '@next/third-parties/google';
+
+/**
+ * The delivery path: the Consent Mode defaults followed by the GTM container.
+ * GA4 is configured inside that container, so there is no separate
+ * `<GoogleAnalytics>` component and therefore no double-tagging.
+ *
+ * Renders nothing when analytics is disabled, so dev and CI never load GTM.
+ */
+const AnalyticsScripts = () => {
+  if (!isAnalyticsEnabled) return null;
+
+  return (
+    <>
+      <ConsentBootstrap />
+      <GoogleTagManager gtmId={GTM_ID} />
+    </>
+  );
+};
+
+export default AnalyticsScripts;

--- a/src/components/analytics/ConsentBootstrap.tsx
+++ b/src/components/analytics/ConsentBootstrap.tsx
@@ -1,0 +1,63 @@
+import { ALL_DENIED, CONSENT_COOKIE, GRANTED_DEFAULT } from '@/lib/analytics/consent';
+import Script from 'next/script';
+
+/**
+ * Sets the Consent Mode v2 defaults before GTM loads.
+ *
+ * `gtag('consent', 'default', …)` is ignored outright if it runs after
+ * `gtm.js`. `<GoogleTagManager>` injects its script `afterInteractive`, so this
+ * inline `beforeInteractive` script in the root layout is what guarantees the
+ * ordering — it is a correctness requirement, not a cosmetic one.
+ *
+ * The script mirrors `resolveConsent()` from `@/lib/analytics/consent` in plain
+ * JS because a `beforeInteractive` inline script cannot import a module. The
+ * category objects are serialized straight from that module so their shape has
+ * a single source of truth; only the cookie/GPC/DNT reads are duplicated as
+ * literal JS.
+ */
+const inlineScript = `
+(function () {
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { window.dataLayer.push(arguments); }
+  window.gtag = window.gtag || gtag;
+
+  var granted = ${JSON.stringify(GRANTED_DEFAULT)};
+  var denied = ${JSON.stringify(ALL_DENIED)};
+
+  var privacySignal =
+    navigator.globalPrivacyControl === true || navigator.doNotTrack === '1';
+
+  var stored = null;
+  if (!privacySignal) {
+    var match = document.cookie
+      .split('; ')
+      .find(function (row) { return row.indexOf('${CONSENT_COOKIE}=') === 0; });
+    if (match) {
+      try {
+        stored = JSON.parse(
+          decodeURIComponent(match.slice('${CONSENT_COOKIE}='.length)),
+        );
+      } catch (e) {
+        stored = null;
+      }
+    }
+  }
+
+  var state = privacySignal ? denied : stored || granted;
+  gtag('consent', 'default', state);
+})();
+`;
+
+const ConsentBootstrap = () => (
+  // The lint rule targets the Pages Router (`pages/_document.js`); in the App
+  // Router the root layout is the required home for a `beforeInteractive`
+  // script, so this is a false positive.
+  // eslint-disable-next-line @next/next/no-before-interactive-script-outside-document
+  <Script
+    id="consent-bootstrap"
+    strategy="beforeInteractive"
+    dangerouslySetInnerHTML={{ __html: inlineScript }}
+  />
+);
+
+export default ConsentBootstrap;

--- a/src/components/analytics/PageViewTracker.tsx
+++ b/src/components/analytics/PageViewTracker.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { track } from '@/lib/analytics/track';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+
+/**
+ * Sends `page_view` from code on every App Router navigation, rather than
+ * trusting GA4's history-change autotracking. This is deterministic and gets
+ * `page_path` right on routes in the chrome-less `(fullscreen)` group such as
+ * `/projects/wo-haere/play`.
+ *
+ * The GTM GA4 config tag must set `send_page_view: false` and GA4 Enhanced
+ * Measurement's history-based page-change tracking must be off, or every
+ * navigation is counted twice.
+ */
+const PageViewTrackerInner = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const query = searchParams.toString();
+    const page_path = query ? `${pathname}?${query}` : pathname;
+
+    track({ name: 'page_view', page_path });
+  }, [pathname, searchParams]);
+
+  return null;
+};
+
+/**
+ * `useSearchParams` opts a route into client-side rendering unless it sits under
+ * a Suspense boundary, so the tracker is wrapped here to keep the rest of the
+ * tree server-rendered.
+ */
+const PageViewTracker = () => (
+  <Suspense fallback={null}>
+    <PageViewTrackerInner />
+  </Suspense>
+);
+
+export default PageViewTracker;

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -1,0 +1,17 @@
+/**
+ * Env reads for the analytics layer. No zod — the surface is three strings and
+ * a boolean, and the whole layer no-ops when they are unset, so a validation
+ * dependency would buy nothing.
+ *
+ * `GTM_ID` and `GA_ID` are public (`NEXT_PUBLIC_`) because the browser needs
+ * them. `GA4_API_SECRET` is server-only (Measurement Protocol, a later layer)
+ * and is deliberately not read here — see `.env.example`. `SITE_URL` lives in
+ * `@/lib/site`.
+ *
+ * Unset ⇒ `isAnalyticsEnabled` is false ⇒ no GTM script renders and `track()`
+ * only logs to the console, so dev and CI stay silent.
+ */
+export const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID ?? '';
+export const GA_ID = process.env.NEXT_PUBLIC_GA_ID ?? '';
+
+export const isAnalyticsEnabled = Boolean(GTM_ID && GA_ID);

--- a/src/lib/analytics/consent.test.ts
+++ b/src/lib/analytics/consent.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ALL_DENIED,
+  GRANTED_DEFAULT,
+  readConsentCookie,
+  resolveConsent,
+  writeConsentCookie,
+} from '@/lib/analytics/consent';
+
+/**
+ * The state machine reads `document` and `navigator` at call time, so each test
+ * stubs the globals it needs. Node 21+ ships a real `navigator`, so a privacy
+ * signal has to be stubbed explicitly rather than assumed absent.
+ */
+const stubNavigator = (
+  props: { globalPrivacyControl?: boolean; doNotTrack?: string } = {},
+) => vi.stubGlobal('navigator', props);
+
+const stubDocument = (cookie = '') => vi.stubGlobal('document', { cookie });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('resolveConsent', () => {
+  it('grants the analytics category by default', () => {
+    stubNavigator();
+    stubDocument('');
+
+    const state = resolveConsent();
+
+    expect(state.analytics_storage).toBe('granted');
+    expect(state).toEqual(GRANTED_DEFAULT);
+  });
+
+  it('leaves the ad categories denied by default', () => {
+    // The site shows no ads, so nothing consumes ad consent — keep it denied.
+    stubNavigator();
+    stubDocument('');
+
+    const state = resolveConsent();
+
+    expect(state.ad_storage).toBe('denied');
+    expect(state.ad_user_data).toBe('denied');
+    expect(state.ad_personalization).toBe('denied');
+  });
+
+  it('forces every category denied when Global Privacy Control is on', () => {
+    stubNavigator({ globalPrivacyControl: true });
+    stubDocument('');
+
+    expect(resolveConsent()).toEqual(ALL_DENIED);
+  });
+
+  it('forces every category denied when Do Not Track is on', () => {
+    stubNavigator({ doNotTrack: '1' });
+    stubDocument('');
+
+    expect(resolveConsent()).toEqual(ALL_DENIED);
+  });
+
+  it('lets a privacy signal override a granting cookie', () => {
+    // A binding opt-out must win even if an older cookie said granted.
+    stubNavigator({ globalPrivacyControl: true });
+    stubDocument(`ow_consent=${encodeURIComponent(JSON.stringify(GRANTED_DEFAULT))}`);
+
+    expect(resolveConsent()).toEqual(ALL_DENIED);
+  });
+});
+
+describe('the ow_consent cookie', () => {
+  it('round-trips a written state back through the reader', () => {
+    stubDocument('');
+    const chosen = { ...GRANTED_DEFAULT, analytics_storage: 'denied' as const };
+
+    writeConsentCookie(chosen);
+
+    expect(readConsentCookie()).toEqual(chosen);
+  });
+
+  it('treats a corrupt cookie as absent rather than throwing', () => {
+    stubDocument('ow_consent=not-json');
+
+    expect(readConsentCookie()).toBeNull();
+  });
+
+  it('reads null when there is no cookie', () => {
+    stubDocument('other=1');
+
+    expect(readConsentCookie()).toBeNull();
+  });
+});

--- a/src/lib/analytics/consent.ts
+++ b/src/lib/analytics/consent.ts
@@ -1,0 +1,94 @@
+/**
+ * Consent Mode v2 state machine.
+ *
+ * Swiss revDSG asks for transparency, not prior opt-in, so the defaults are
+ * granted for the categories this site actually uses. The site runs GA4 only
+ * and shows no ads, so the ad_* categories stay denied — nothing would consume
+ * that consent anyway.
+ *
+ * A browser-level privacy signal (Global Privacy Control or Do Not Track)
+ * overrides everything and forces all categories to denied. Otherwise a
+ * first-party `ow_consent` cookie remembers a prior choice; absent that, the
+ * granted defaults apply.
+ *
+ * The `ConsentBootstrap` inline script re-implements `resolveConsent` in plain
+ * JS (it cannot import this module), so the category shapes below are the single
+ * source of truth it serializes — keep them plain JSON-serialisable objects.
+ */
+export type ConsentValue = 'granted' | 'denied';
+
+export type ConsentState = {
+  ad_storage: ConsentValue;
+  ad_user_data: ConsentValue;
+  ad_personalization: ConsentValue;
+  analytics_storage: ConsentValue;
+  functionality_storage: ConsentValue;
+  personalization_storage: ConsentValue;
+  security_storage: ConsentValue;
+};
+
+export const GRANTED_DEFAULT: ConsentState = {
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  analytics_storage: 'granted',
+  functionality_storage: 'granted',
+  personalization_storage: 'granted',
+  security_storage: 'granted',
+};
+
+export const ALL_DENIED: ConsentState = {
+  ad_storage: 'denied',
+  ad_user_data: 'denied',
+  ad_personalization: 'denied',
+  analytics_storage: 'denied',
+  functionality_storage: 'denied',
+  personalization_storage: 'denied',
+  security_storage: 'denied',
+};
+
+export const CONSENT_COOKIE = 'ow_consent';
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export const readConsentCookie = (): ConsentState | null => {
+  if (typeof document === 'undefined') return null;
+
+  const match = document.cookie
+    .split('; ')
+    .find(row => row.startsWith(`${CONSENT_COOKIE}=`));
+  if (!match) return null;
+
+  try {
+    return JSON.parse(decodeURIComponent(match.slice(CONSENT_COOKIE.length + 1)));
+  } catch {
+    // A tampered or truncated cookie is treated as absent rather than throwing.
+    return null;
+  }
+};
+
+export const writeConsentCookie = (state: ConsentState): void => {
+  if (typeof document === 'undefined') return;
+
+  const value = encodeURIComponent(JSON.stringify(state));
+  document.cookie = `${CONSENT_COOKIE}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+};
+
+/**
+ * A browser privacy signal is a legally binding opt-out; it wins over the cookie
+ * and the defaults alike.
+ */
+export const isPrivacySignalOn = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+
+  return (
+    (navigator as Navigator & { globalPrivacyControl?: boolean })
+      .globalPrivacyControl === true || navigator.doNotTrack === '1'
+  );
+};
+
+export const resolveConsent = (): ConsentState => {
+  if (isPrivacySignalOn()) return ALL_DENIED;
+
+  return readConsentCookie() ?? GRANTED_DEFAULT;
+};

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_EVENT_NAME_LENGTH,
+  MAX_EVENT_PARAMS,
+  isValidEvent,
+  type AnalyticsEvent,
+} from '@/lib/analytics/events';
+
+/**
+ * GA4 drops an over-limit event silently, so these limits guard the contract:
+ * a later layer that adds a too-long name or too many params fails here rather
+ * than losing hits in production with no signal.
+ */
+describe('GA4 event limits', () => {
+  it('pins the documented GA4 limits', () => {
+    expect(MAX_EVENT_NAME_LENGTH).toBe(40);
+    expect(MAX_EVENT_PARAMS).toBe(25);
+  });
+});
+
+describe('isValidEvent', () => {
+  it('accepts the seeded page_view event', () => {
+    expect(isValidEvent({ name: 'page_view', page_path: '/' })).toBe(true);
+  });
+
+  it('rejects a name longer than the limit', () => {
+    const event = {
+      name: 'x'.repeat(MAX_EVENT_NAME_LENGTH + 1),
+      page_path: '/',
+    } as unknown as AnalyticsEvent;
+
+    expect(isValidEvent(event)).toBe(false);
+  });
+
+  it('rejects an event with more than the allowed parameters', () => {
+    // `name` is the discriminant, not a parameter, so it is excluded from the
+    // count — hence one more key than the param limit.
+    const params = Object.fromEntries(
+      Array.from({ length: MAX_EVENT_PARAMS + 1 }, (_, i) => [`p${i}`, i]),
+    );
+    const event = { name: 'page_view', ...params } as unknown as AnalyticsEvent;
+
+    expect(isValidEvent(event)).toBe(false);
+  });
+
+  it('does not count the name toward the parameter budget', () => {
+    const params = Object.fromEntries(
+      Array.from({ length: MAX_EVENT_PARAMS }, (_, i) => [`p${i}`, i]),
+    );
+    const event = { name: 'page_view', ...params } as unknown as AnalyticsEvent;
+
+    expect(isValidEvent(event)).toBe(true);
+  });
+});

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,32 @@
+/**
+ * The event contract. Every later analytics layer adds a member to this
+ * discriminated union rather than inventing its own push shape, so the whole
+ * app speaks one vocabulary and `track()` stays the single entry point.
+ *
+ * `name` is the discriminant and becomes the GA4 event name. The rest of an
+ * event's own keys become GA4 event parameters.
+ */
+export type PageViewEvent = {
+  name: 'page_view';
+  page_path: string;
+  page_title?: string;
+};
+
+export type AnalyticsEvent = PageViewEvent;
+
+/**
+ * GA4 silently drops an event whose name exceeds 40 characters or that carries
+ * more than 25 parameters — no error, no console warning, the hit just never
+ * lands. `isValidEvent` is the runtime guard the tests pin against, because the
+ * union above vanishes at compile time and cannot check a value at runtime.
+ */
+export const MAX_EVENT_NAME_LENGTH = 40;
+export const MAX_EVENT_PARAMS = 25;
+
+export const isValidEvent = (event: AnalyticsEvent): boolean => {
+  const paramCount = Object.keys(event).filter(key => key !== 'name').length;
+
+  return (
+    event.name.length <= MAX_EVENT_NAME_LENGTH && paramCount <= MAX_EVENT_PARAMS
+  );
+};

--- a/src/lib/analytics/track.test.ts
+++ b/src/lib/analytics/track.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AnalyticsEvent } from '@/lib/analytics/events';
+
+/**
+ * `config` reads the env at module load, so toggling analytics on/off means
+ * re-importing `track` after stubbing the env. `resolveConsent` reads the
+ * globals at call time, so consent and the window `dataLayer` are stubbed
+ * directly.
+ */
+const importTrack = async () => {
+  vi.resetModules();
+  return (await import('@/lib/analytics/track')).track;
+};
+
+const enableAnalytics = () => {
+  vi.stubEnv('NEXT_PUBLIC_GTM_ID', 'GTM-TEST');
+  vi.stubEnv('NEXT_PUBLIC_GA_ID', 'G-TEST');
+};
+
+const grantConsent = () => vi.stubGlobal('navigator', {});
+
+const pageView: AnalyticsEvent = { name: 'page_view', page_path: '/' };
+
+beforeEach(() => {
+  vi.stubGlobal('window', {});
+  vi.stubGlobal('document', { cookie: '' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('track', () => {
+  it('no-ops and logs to the console when analytics is disabled', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GTM_ID', '');
+    vi.stubEnv('NEXT_PUBLIC_GA_ID', '');
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const track = await importTrack();
+
+    track(pageView);
+
+    expect(debug).toHaveBeenCalledWith('[analytics]', pageView);
+    expect(window.dataLayer).toBeUndefined();
+  });
+
+  it('no-ops when analytics consent is denied', async () => {
+    enableAnalytics();
+    vi.stubGlobal('navigator', { globalPrivacyControl: true });
+    const track = await importTrack();
+
+    track(pageView);
+
+    expect(window.dataLayer).toBeUndefined();
+  });
+
+  it('pushes exactly once to the dataLayer when enabled and granted', async () => {
+    enableAnalytics();
+    grantConsent();
+    const track = await importTrack();
+
+    track(pageView);
+
+    expect(window.dataLayer).toEqual([{ event: 'page_view', page_path: '/' }]);
+  });
+
+  it('does not double-push on repeated calls', async () => {
+    enableAnalytics();
+    grantConsent();
+    const track = await importTrack();
+
+    track(pageView);
+    track({ name: 'page_view', page_path: '/about' });
+
+    expect(window.dataLayer).toHaveLength(2);
+  });
+});

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -1,0 +1,42 @@
+import { isAnalyticsEnabled } from '@/lib/analytics/config';
+import { resolveConsent } from '@/lib/analytics/consent';
+import { isValidEvent, type AnalyticsEvent } from '@/lib/analytics/events';
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * The single entry point every layer uses to emit an event. It pushes to the
+ * GTM `dataLayer`; GA4 is configured inside the container to read from there.
+ *
+ * No-ops in two cases, both by design:
+ *   - analytics disabled (env unset) — logs to the console instead, so dev and
+ *     CI produce a visible trail without a real container;
+ *   - analytics consent not granted — respects the Consent Mode state machine.
+ *
+ * When it does fire it pushes exactly once, flattening the event's parameters
+ * next to a GA4 `event` name.
+ */
+export const track = (event: AnalyticsEvent): void => {
+  if (!isAnalyticsEnabled) {
+    console.debug('[analytics]', event);
+    return;
+  }
+
+  if (resolveConsent().analytics_storage !== 'granted') return;
+
+  if (typeof window === 'undefined') return;
+
+  if (process.env.NODE_ENV !== 'production' && !isValidEvent(event)) {
+    console.warn('[analytics] event exceeds GA4 limits, will be dropped', event);
+  }
+
+  const { name, ...params } = event;
+
+  window.dataLayer ??= [];
+  window.dataLayer.push({ event: name, ...params });
+};


### PR DESCRIPTION
## Summary

Foundation for the analytics stack (#398): installs the GTM delivery path and the typed event contract every later layer pushes into. The layer no-ops entirely when its env vars are unset, so dev and CI stay silent.

## Changes

- **Delivery lib** (`src/lib/analytics/`): env-driven `config`, an `AnalyticsEvent` discriminated union seeded with `page_view`, a Consent Mode v2 state machine (granted defaults, GPC/DNT force denied, `ow_consent` cookie), and `track()` pushing to the GTM `dataLayer` — plus unit tests.
- **Components** (`src/components/analytics/`): `ConsentBootstrap` (inline `beforeInteractive` consent defaults, run before `gtm.js`), `AnalyticsScripts` (bootstrap + `GoogleTagManager`, or `null` when disabled), and `PageViewTracker` (per-navigation `page_view` inside a Suspense boundary).
- **Wiring**: mount both in the root layout; add `@next/third-parties` and document the three env vars in `.env.example`.

## Additional Notes

GA4 is configured inside the GTM container (no `<GoogleAnalytics>`, so no double-tagging). Two manual dashboard steps are required for correctness: set the GA4 config tag's `send_page_view: false`, and turn off GA4 Enhanced Measurement's history-based page-change tracking (otherwise navigations double-count). Closes #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)