### PR TITLE
feat(analytics): add cookie notice and /privacy page

### DIFF
--- a/src/app/(site)/privacy/page.tsx
+++ b/src/app/(site)/privacy/page.tsx
@@ -1,0 +1,85 @@
+import { A, P, Section, Table } from '@/components/projects/Prose';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy',
+  description:
+    'What this site collects, which cookies it sets, and how to opt out. Google Analytics with a granted-by-default consent choice, plus cookieless Vercel Analytics.',
+  alternates: {
+    canonical: '/privacy',
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <article className="w-full max-w-3xl">
+      <header className="flex flex-col gap-4">
+        <h1 className="text-4xl font-medium text-balance italic sm:text-5xl">
+          Privacy
+        </h1>
+        <P>
+          This is a personal portfolio. It collects only what it takes to see
+          which work holds attention and where the site falls short — nothing is
+          sold, and there are no advertising trackers.
+        </P>
+      </header>
+
+      <Section title="Analytics">
+        <P>
+          Usage is measured with Google Analytics 4, delivered through Google
+          Tag Manager. It records pseudonymous events — pages viewed,
+          interactions, an approximate location derived from your IP address,
+          and basic device and browser details. It does not identify you by
+          name.
+        </P>
+        <P>
+          Consent defaults to <em>granted</em>: Swiss data-protection law
+          (revDSG) asks for transparency and a real opt-out rather than an
+          up-front barrier. A notice at the bottom of the page tells you this on
+          your first visit and lets you opt out in one click.
+        </P>
+      </Section>
+
+      <Section title="Cookies">
+        <P>These are the only cookies involved:</P>
+        <Table
+          head={['Cookie', 'Set by', 'Purpose']}
+          rows={[
+            [
+              <code key="ga">_ga</code>,
+              'Google Analytics',
+              'Distinguishes one visitor from another.',
+            ],
+            [
+              <code key="gaid">_ga_&lt;id&gt;</code>,
+              'Google Analytics',
+              'Keeps session state for a single property.',
+            ],
+            [
+              <code key="ow">ow_consent</code>,
+              'This site',
+              'Remembers your analytics choice so the notice appears once.',
+            ],
+          ]}
+        />
+        <P>
+          Vercel Analytics also runs on the site for aggregate traffic and Core
+          Web Vitals. It is cookieless and stores no personal data.
+        </P>
+      </Section>
+
+      <Section title="Opting out">
+        <P>
+          Choose <strong>Opt out</strong> in the notice at any time — it stops
+          Google Analytics from collecting anything further and remembers the
+          choice across visits. You can also block or clear cookies in your
+          browser, or install Google&rsquo;s{' '}
+          <A href="https://tools.google.com/dlpage/gaoptout">
+            opt-out browser add-on
+          </A>
+          .
+        </P>
+      </Section>
+    </article>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import CookieNotice from '@/components/analytics/CookieNotice';
 import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -97,6 +98,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         {children}
+        <CookieNotice />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,5 +32,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly',
       priority: 0.8,
     },
+    {
+      url: `${SITE_URL}/privacy`,
+      lastModified: SITE_LAST_MODIFIED,
+      changeFrequency: 'monthly',
+      priority: 0.3,
+    },
   ];
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,6 +34,7 @@ const Footer = () => (
           <Column>
             <FooterLabel>Resources</FooterLabel>
             <CustomLink link="/design">Design</CustomLink>
+            <CustomLink link="/privacy">Privacy</CustomLink>
           </Column>
         </div>
       </nav>

--- a/src/components/analytics/CookieNotice.tsx
+++ b/src/components/analytics/CookieNotice.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { denyAll, grantAll, readConsent } from '@/lib/analytics/consent';
+import { cn } from '@/lib/wo-haere/cn';
+import { Toast } from '@base-ui/react/toast';
+import Link from 'next/link';
+import { useEffect, useRef } from 'react';
+
+const NOTICE_ID = 'ow-consent-notice';
+
+/**
+ * Shows the notice once, only when no choice is stored in the `ow_consent`
+ * cookie. `timeout: 0` keeps it up until the visitor acts; `priority: 'low'`
+ * lets Base UI announce it politely (equivalent to `aria-live="polite"`), so no
+ * second live region is added.
+ */
+function ConsentTrigger() {
+  const manager = Toast.useToastManager();
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (shown.current || readConsent() !== null) return;
+    shown.current = true;
+    manager.add({
+      id: NOTICE_ID,
+      title: 'Cookies & analytics',
+      description:
+        'This site uses Google Analytics to see how it is used, and Vercel Analytics for aggregate traffic. You can opt out at any time.',
+      timeout: 0,
+      priority: 'low',
+    });
+  }, [manager]);
+
+  return null;
+}
+
+function ConsentToasts() {
+  const { toasts, close } = Toast.useToastManager();
+
+  return toasts.map(toast => (
+    <Toast.Root
+      key={toast.id}
+      toast={toast}
+      className={cn(
+        'border-line bg-background text-foreground',
+        'w-[min(28rem,calc(100vw-2rem))] rounded-2xl border p-4 shadow-lg',
+      )}
+    >
+      <Toast.Title className="text-sm font-medium" />
+      <Toast.Description className="text-muted mt-1 text-sm text-pretty" />
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            grantAll();
+            close(toast.id);
+          }}
+          className="bg-foreground text-background rounded-full px-4 py-1.5 text-sm font-medium hover:opacity-90"
+        >
+          Got it
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            denyAll();
+            close(toast.id);
+          }}
+          className="border-line hover:border-foreground rounded-full border px-4 py-1.5 text-sm font-medium"
+        >
+          Opt out
+        </button>
+        <Link
+          href="/privacy"
+          className="text-muted hover:text-foreground ml-auto text-sm underline underline-offset-2"
+        >
+          Privacy
+        </Link>
+      </div>
+    </Toast.Root>
+  ));
+}
+
+export default function CookieNotice() {
+  return (
+    <Toast.Provider>
+      <ConsentTrigger />
+      <Toast.Portal>
+        <Toast.Viewport
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex justify-center',
+            'px-4 pt-4 pb-[max(1rem,env(safe-area-inset-bottom))]',
+          )}
+        >
+          <ConsentToasts />
+        </Toast.Viewport>
+      </Toast.Portal>
+    </Toast.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
Consent defaults to granted (Swiss revDSG asks for transparency, not opt-in), so the site needs a notice with a real opt-out and a page saying what's collected. This adds both.

## Changes
- Add `/privacy` page (`src/app/(site)/privacy/page.tsx`) — plain prose on what GA4 collects, the cookies involved (`_ga`, `_ga_<id>`, `ow_consent`), cookieless Vercel Analytics, and how to opt out.
- List `/privacy` in the sitemap and link it from the footer Resources column.
- Add `CookieNotice` (`src/components/analytics/CookieNotice.tsx`) — a bottom notice on `@base-ui/react/toast`: shown once, persistent, announced politely, no animation, with **Got it** / **Opt out** / a `/privacy` link. Rendered in the root layout.

## Additional Notes
Consent side effects live in the #398 foundation: `CookieNotice` imports `denyAll`/`grantAll`/`readConsent` from `@/lib/analytics/consent`, which does not exist until this branch is rebased onto `issue-398` — so it does not build standalone yet and should merge after #398.

Closes #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)