### PR TITLE
feat(analytics): report Core Web Vitals to GA4

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import AnalyticsScripts from '@/components/analytics/AnalyticsScripts';
 import PageViewTracker from '@/components/analytics/PageViewTracker';
+import WebVitalsTracker from '@/components/analytics/WebVitalsTracker';
 import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -101,6 +102,7 @@ export default function RootLayout({
         />
         {children}
         <PageViewTracker />
+        <WebVitalsTracker />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/analytics/WebVitalsTracker.tsx
+++ b/src/components/analytics/WebVitalsTracker.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { track } from '@/lib/analytics/track';
+import { usePathname } from 'next/navigation';
+import { useReportWebVitals } from 'next/web-vitals';
+
+/**
+ * Copies each Core Web Vital into GA4 as a `web_vitals` event. `<SpeedInsights />`
+ * stays the source of record; this copy adds segmentation — a regression can be
+ * traced to a route, device class or referrer inside GA4, next to the
+ * behavioural events.
+ *
+ * GA4 metrics are integers, so values are rounded and CLS is scaled by 1000 —
+ * an unscaled CLS of `0.07` would otherwise land as `0`.
+ */
+const WebVitalsTracker = () => {
+  const pathname = usePathname();
+
+  useReportWebVitals(metric => {
+    const metric_value =
+      metric.name === 'CLS'
+        ? Math.round(metric.value * 1000)
+        : Math.round(metric.value);
+
+    track({
+      name: 'web_vitals',
+      metric_name: metric.name,
+      metric_value,
+      metric_rating: metric.rating,
+      metric_id: metric.id,
+      page_path: pathname,
+    });
+  });
+
+  return null;
+};
+
+export default WebVitalsTracker;

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -24,6 +24,19 @@ describe('isValidEvent', () => {
     expect(isValidEvent({ name: 'page_view', page_path: '/' })).toBe(true);
   });
 
+  it('accepts the seeded web_vitals event', () => {
+    expect(
+      isValidEvent({
+        name: 'web_vitals',
+        metric_name: 'CLS',
+        metric_value: 70,
+        metric_rating: 'good',
+        metric_id: 'v5-1700000000000-1234567890123',
+        page_path: '/',
+      }),
+    ).toBe(true);
+  });
+
   it('rejects a name longer than the limit', () => {
     const event = {
       name: 'x'.repeat(MAX_EVENT_NAME_LENGTH + 1),

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -12,7 +12,16 @@ export type PageViewEvent = {
   page_title?: string;
 };
 
-export type AnalyticsEvent = PageViewEvent;
+export type WebVitalsEvent = {
+  name: 'web_vitals';
+  metric_name: string;
+  metric_value: number;
+  metric_rating: 'good' | 'needs-improvement' | 'poor';
+  metric_id: string;
+  page_path: string;
+};
+
+export type AnalyticsEvent = PageViewEvent | WebVitalsEvent;
 
 /**
  * GA4 silently drops an event whose name exceeds 40 characters or that carries


### PR DESCRIPTION
## Summary
Speed Insights records Core Web Vitals but offers no GA4 segmentation. This adds a thin client tracker that copies each vital into GA4 as a `web_vitals` event, making a regression traceable to a specific route, device class or referrer alongside the behavioural events.

## Changes
- Add a `web_vitals` member to the `AnalyticsEvent` contract (`metric_name`, `metric_value`, `metric_rating`, `metric_id`, `page_path`) and pin it with an `isValidEvent` test case.
- Add `WebVitalsTracker` — a `'use client'` component using `useReportWebVitals` from `next/web-vitals` that emits via the shared `track()` helper; values are rounded and CLS is scaled by 1000 so GA4's integer metrics keep precision.
- Mount `<WebVitalsTracker />` beside `<PageViewTracker />` in the root layout.

## Additional Notes
- Zero new dependencies — `useReportWebVitals` ships with Next.js. No direct `dataLayer` access; `track()` already gates on enablement + consent.
- `<SpeedInsights />` stays the source of record; this is a segmentation copy, not a replacement.
- `page_path` uses `usePathname` only, so no Suspense wrapper is needed.

Closes #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)