### PR TITLE
feat(analytics): track link, nav and 404 events

### DIFF
--- a/src/app/(site)/projects/inputmetrics/page.tsx
+++ b/src/app/(site)/projects/inputmetrics/page.tsx
@@ -51,7 +51,11 @@ export default function InputMetricsCaseStudy() {
           thing it is capable of.
         </P>
         <p className="text-muted text-sm">{project.stack.join(' · ')}</p>
-        <ProjectLinks links={project.links} className="mt-2" />
+        <ProjectLinks
+          links={project.links}
+          slug={project.slug}
+          className="mt-2"
+        />
       </header>
 
       <Image
@@ -484,7 +488,7 @@ export default function InputMetricsCaseStudy() {
       </Section>
 
       <div className="border-foreground/20 mt-16 border-t pt-8">
-        <ProjectLinks links={project.links} />
+        <ProjectLinks links={project.links} slug={project.slug} />
       </div>
     </article>
   );

--- a/src/app/(site)/projects/macvitals/page.tsx
+++ b/src/app/(site)/projects/macvitals/page.tsx
@@ -51,7 +51,11 @@ export default function MacVitalsCaseStudy() {
           most of the work was in finding out what to call.
         </P>
         <p className="text-muted text-sm">{project.stack.join(' · ')}</p>
-        <ProjectLinks links={project.links} className="mt-2" />
+        <ProjectLinks
+          links={project.links}
+          slug={project.slug}
+          className="mt-2"
+        />
       </header>
 
       <Image
@@ -452,7 +456,7 @@ export default function MacVitalsCaseStudy() {
       </Section>
 
       <div className="border-foreground/20 mt-16 border-t pt-8">
-        <ProjectLinks links={project.links} />
+        <ProjectLinks links={project.links} slug={project.slug} />
       </div>
     </article>
   );

--- a/src/app/(site)/projects/wo-haere/page.tsx
+++ b/src/app/(site)/projects/wo-haere/page.tsx
@@ -44,7 +44,11 @@ export default function WoHaereCaseStudy() {
           component in here would land ~250KB gz of maplibre on a page that is
           mostly prose.
         */}
-        <ProjectLinks links={project.links} className="mt-2" />
+        <ProjectLinks
+          links={project.links}
+          slug={project.slug}
+          className="mt-2"
+        />
       </header>
 
       <Image
@@ -319,7 +323,7 @@ export default function WoHaereCaseStudy() {
       </Section>
 
       <div className="border-foreground/20 mt-16 border-t pt-8">
-        <ProjectLinks links={project.links} />
+        <ProjectLinks links={project.links} slug={project.slug} />
       </div>
     </article>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import AnalyticsScripts from '@/components/analytics/AnalyticsScripts';
+import OutboundLinkDelegate from '@/components/analytics/OutboundLinkDelegate';
 import PageViewTracker from '@/components/analytics/PageViewTracker';
 import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
@@ -100,6 +101,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         {children}
+        <OutboundLinkDelegate />
         <PageViewTracker />
         <Analytics />
         <SpeedInsights />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,4 @@
+import PageNotFoundTracker from '@/components/analytics/PageNotFoundTracker';
 import SiteChrome from '@/components/SiteChrome';
 import Link from 'next/link';
 
@@ -9,6 +10,7 @@ import Link from 'next/link';
 export default function NotFound() {
   return (
     <SiteChrome>
+      <PageNotFoundTracker />
       <div className="flex flex-col items-center gap-4">
         <h1 className="text-4xl font-medium">404</h1>
         <p className="text-muted">This page could not be found.</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,9 +17,13 @@ const Footer = () => (
         <div className="grid grid-cols-4 items-start gap-8 py-16 sm:grid-cols-8 lg:grid-cols-12">
           <Column>
             <FooterLabel>Pages</FooterLabel>
-            <CustomLink link="/">Home</CustomLink>
-            <CustomLink link="/projects">Projects</CustomLink>
-            {/* <CustomLink link="/gallery">Gallery</CustomLink> */}
+            <CustomLink link="/" nav>
+              Home
+            </CustomLink>
+            <CustomLink link="/projects" nav>
+              Projects
+            </CustomLink>
+            {/* <CustomLink link="/gallery" nav>Gallery</CustomLink> */}
           </Column>
 
           <Column>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { track } from '@/lib/analytics/track';
+import { handledMarker, linkFields } from '@/lib/analytics/links';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { type ReactNode } from 'react';
+import { type MouseEvent, type ReactNode } from 'react';
 
 const navigation = [
   { name: 'Home', href: '/' },
@@ -23,6 +25,16 @@ const NavItem = ({
   // A prefix match so /projects/wo-haere keeps Projects highlighted; '/' would
   // otherwise prefix-match everything, so it stays exact.
   const isActive = href === '/' ? pathname === href : pathname.startsWith(href);
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const anchor = event.currentTarget;
+    const { link_url, link_text } = linkFields(
+      anchor.href,
+      anchor.textContent ?? '',
+    );
+
+    track({ name: 'nav_click', link_url, link_text, nav_location: 'header' });
+  };
 
   const styles = {
     link: ({ isActive }: { isActive: boolean }) =>
@@ -58,7 +70,12 @@ const NavItem = ({
 
   return (
     <li className={className}>
-      <Link href={href} className={styles.link({ isActive })}>
+      <Link
+        href={href}
+        className={styles.link({ isActive })}
+        onClick={handleClick}
+        {...handledMarker}
+      >
         {children}
         {isActive && <span className={styles.activeLink} />}
       </Link>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,17 +1,50 @@
-import IconLink from '@/icons/Link';
-import Link from 'next/link';
-import { ReactNode } from 'react';
+'use client';
 
+import IconLink from '@/icons/Link';
+import { track } from '@/lib/analytics/track';
+import { handledMarker, linkFields } from '@/lib/analytics/links';
+import Link from 'next/link';
+import { MouseEvent, ReactNode } from 'react';
+
+/**
+ * The content-link chokepoint: home page and footer route through here, so it is
+ * the natural place to emit link-click events. `nav` flips the emitted event to
+ * `nav_click` for the footer's primary navigation; every other link is an
+ * `outbound_click` or `internal_link_click`. Each click is stamped with the
+ * handled marker so the document delegate does not re-count it.
+ */
 const CustomLink = ({
   link,
   children,
   className,
+  nav,
 }: {
   link: string;
   children: ReactNode;
   className?: string;
+  nav?: boolean;
 }) => {
   const isExternal = link.startsWith('http');
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const anchor = event.currentTarget;
+    const fields = linkFields(anchor.href, anchor.textContent ?? '');
+
+    if (nav) {
+      track({
+        name: 'nav_click',
+        link_url: fields.link_url,
+        link_text: fields.link_text,
+        nav_location: 'footer',
+      });
+      return;
+    }
+
+    track({
+      name: isExternal ? 'outbound_click' : 'internal_link_click',
+      ...fields,
+    });
+  };
 
   const styles = {
     link: [
@@ -35,6 +68,8 @@ const CustomLink = ({
       className={`${styles.link} ${className || ''}`}
       target={isExternal ? '_blank' : '_self'}
       rel={isExternal ? 'noopener noreferrer' : undefined}
+      onClick={handleClick}
+      {...handledMarker}
     >
       {children}
       {isExternal && <IconLink />}

--- a/src/components/analytics/OutboundLinkDelegate.tsx
+++ b/src/components/analytics/OutboundLinkDelegate.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { track } from '@/lib/analytics/track';
+import {
+  ANALYTICS_HANDLED_ATTR,
+  isOutbound,
+  linkFields,
+} from '@/lib/analytics/links';
+import { useEffect } from 'react';
+
+/**
+ * A document-level catch-all for outbound clicks. `/design` renders MDX fetched
+ * from GitHub at request time, so its links are raw `<a>` elements that never
+ * pass through `CustomLink` or the citation link — nothing else would track
+ * them. React-handled anchors carry the handled marker and are skipped here, so
+ * a normal outbound click fires exactly once.
+ *
+ * Renders nothing; it only attaches a single delegated listener for the app.
+ */
+const OutboundLinkDelegate = () => {
+  useEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('a');
+
+      if (!anchor) return;
+      if (anchor.hasAttribute(ANALYTICS_HANDLED_ATTR)) return;
+      if (!isOutbound(anchor.href, window.location.host)) return;
+
+      track({
+        name: 'outbound_click',
+        ...linkFields(anchor.href, anchor.textContent ?? ''),
+      });
+    };
+
+    document.addEventListener('click', handleClick);
+
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
+  return null;
+};
+
+export default OutboundLinkDelegate;

--- a/src/components/analytics/PageNotFoundTracker.tsx
+++ b/src/components/analytics/PageNotFoundTracker.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { track } from '@/lib/analytics/track';
+import { useEffect } from 'react';
+
+/**
+ * Emits `page_not_found` for the URL that missed. The 404 boundary is a server
+ * component, so this small client child reads the attempted path and referrer
+ * from the browser and fires once on mount.
+ */
+const PageNotFoundTracker = () => {
+  useEffect(() => {
+    track({
+      name: 'page_not_found',
+      page_path: window.location.pathname + window.location.search,
+      referrer: document.referrer,
+    });
+  }, []);
+
+  return null;
+};
+
+export default PageNotFoundTracker;

--- a/src/components/projects/Citation.tsx
+++ b/src/components/projects/Citation.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { track } from '@/lib/analytics/track';
+import { handledMarker, linkFields } from '@/lib/analytics/links';
+import { MouseEvent, ReactNode } from 'react';
+
+/**
+ * Citations mid-sentence. Links that are calls to action belong in Project.links.
+ *
+ * Split out of Prose so this single anchor can own the `'use client'` boundary
+ * and emit `citation_click` on click, while Prose's other elements stay server
+ * components. The handled marker keeps the document delegate from re-counting it.
+ */
+export const A = ({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) => {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const anchor = event.currentTarget;
+
+    track({
+      name: 'citation_click',
+      ...linkFields(anchor.href, anchor.textContent ?? ''),
+    });
+  };
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="border-line hover:border-foreground hover:text-foreground border-b transition-colors"
+      onClick={handleClick}
+      {...handledMarker}
+    >
+      {children}
+    </a>
+  );
+};

--- a/src/components/projects/Links.tsx
+++ b/src/components/projects/Links.tsx
@@ -1,5 +1,9 @@
+'use client';
+
 import type { ProjectLink } from '@/data/projects';
 import IconLink from '@/icons/Link';
+import { track } from '@/lib/analytics/track';
+import { handledMarker } from '@/lib/analytics/links';
 import Link from 'next/link';
 
 /**
@@ -7,17 +11,34 @@ import Link from 'next/link';
  * build, and /projects/wo-haere/play pulls ~250KB gz of maplibre onto a page that
  * is mostly prose — a hover would do exactly what prefetch does. Absolute URLs
  * ignore the prop, so it is unconditional rather than a field on ProjectLink.
+ *
+ * Every button is a `project_cta_click`; a `Download` label additionally emits
+ * `download_click`, since the release buttons are the site's only downloads.
  */
 const ProjectLinks = ({
   links,
+  slug,
   className,
 }: {
   links: ProjectLink[];
+  slug: string;
   className?: string;
 }) => (
   <ul className={`flex flex-wrap gap-2 ${className || ''}`}>
     {links.map(({ label, href }) => {
       const isExternal = href.startsWith('http');
+
+      const handleClick = () => {
+        track({
+          name: 'project_cta_click',
+          project_slug: slug,
+          cta_label: label,
+        });
+
+        if (label === 'Download') {
+          track({ name: 'download_click', project_slug: slug, link_url: href });
+        }
+      };
 
       return (
         <li key={href}>
@@ -27,6 +48,8 @@ const ProjectLinks = ({
             target={isExternal ? '_blank' : undefined}
             rel={isExternal ? 'noopener noreferrer' : undefined}
             className="border-line hover:border-foreground hover:bg-foreground hover:text-background inline-flex w-fit items-center gap-1.5 rounded-md border px-4 py-2 text-sm transition-colors"
+            onClick={handleClick}
+            {...handledMarker}
           >
             {label}
             {isExternal ? <IconLink /> : <span aria-hidden="true">→</span>}

--- a/src/components/projects/Prose.tsx
+++ b/src/components/projects/Prose.tsx
@@ -2,6 +2,8 @@ import type { Screenshot } from '@/data/projects';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 
+export { A } from './Citation';
+
 export const Section = ({
   title,
   children,
@@ -17,24 +19,6 @@ export const Section = ({
 
 export const P = ({ children }: { children: ReactNode }) => (
   <p className="text-muted text-pretty">{children}</p>
-);
-
-/** Citations mid-sentence. Links that are calls to action belong in Project.links. */
-export const A = ({
-  href,
-  children,
-}: {
-  href: string;
-  children: ReactNode;
-}) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    className="border-line hover:border-foreground hover:text-foreground border-b transition-colors"
-  >
-    {children}
-  </a>
 );
 
 export const Table = ({

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -24,6 +24,48 @@ describe('isValidEvent', () => {
     expect(isValidEvent({ name: 'page_view', page_path: '/' })).toBe(true);
   });
 
+  it('accepts the link, nav and 404 events', () => {
+    const events: AnalyticsEvent[] = [
+      {
+        name: 'outbound_click',
+        link_url: 'https://github.com/owieth',
+        link_text: 'GitHub',
+        link_domain: 'github.com',
+      },
+      {
+        name: 'internal_link_click',
+        link_url: 'https://olivierwinkler.com/projects',
+        link_text: 'Projects',
+        link_domain: 'olivierwinkler.com',
+      },
+      {
+        name: 'nav_click',
+        link_url: 'https://olivierwinkler.com/',
+        link_text: 'Home',
+        nav_location: 'header',
+      },
+      {
+        name: 'project_cta_click',
+        project_slug: 'macvitals',
+        cta_label: 'Source',
+      },
+      {
+        name: 'download_click',
+        project_slug: 'macvitals',
+        link_url: 'https://github.com/owieth/MacVitals/releases/latest',
+      },
+      {
+        name: 'citation_click',
+        link_url: 'https://example.com/paper',
+        link_text: 'the paper',
+        link_domain: 'example.com',
+      },
+      { name: 'page_not_found', page_path: '/nope', referrer: '' },
+    ];
+
+    for (const event of events) expect(isValidEvent(event)).toBe(true);
+  });
+
   it('rejects a name longer than the limit', () => {
     const event = {
       name: 'x'.repeat(MAX_EVENT_NAME_LENGTH + 1),

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -12,7 +12,61 @@ export type PageViewEvent = {
   page_title?: string;
 };
 
-export type AnalyticsEvent = PageViewEvent;
+export type OutboundClickEvent = {
+  name: 'outbound_click';
+  link_url: string;
+  link_text: string;
+  link_domain: string;
+};
+
+export type InternalLinkClickEvent = {
+  name: 'internal_link_click';
+  link_url: string;
+  link_text: string;
+  link_domain: string;
+};
+
+export type NavClickEvent = {
+  name: 'nav_click';
+  link_url: string;
+  link_text: string;
+  nav_location: 'header' | 'footer';
+};
+
+export type ProjectCtaClickEvent = {
+  name: 'project_cta_click';
+  project_slug: string;
+  cta_label: string;
+};
+
+export type DownloadClickEvent = {
+  name: 'download_click';
+  project_slug: string;
+  link_url: string;
+};
+
+export type CitationClickEvent = {
+  name: 'citation_click';
+  link_url: string;
+  link_text: string;
+  link_domain: string;
+};
+
+export type PageNotFoundEvent = {
+  name: 'page_not_found';
+  page_path: string;
+  referrer: string;
+};
+
+export type AnalyticsEvent =
+  | PageViewEvent
+  | OutboundClickEvent
+  | InternalLinkClickEvent
+  | NavClickEvent
+  | ProjectCtaClickEvent
+  | DownloadClickEvent
+  | CitationClickEvent
+  | PageNotFoundEvent;
 
 /**
  * GA4 silently drops an event whose name exceeds 40 characters or that carries

--- a/src/lib/analytics/links.test.ts
+++ b/src/lib/analytics/links.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOutbound, linkFields } from '@/lib/analytics/links';
+
+describe('linkFields', () => {
+  it('splits an absolute url into url, text and domain', () => {
+    expect(linkFields('https://github.com/owieth', 'GitHub')).toEqual({
+      link_url: 'https://github.com/owieth',
+      link_text: 'GitHub',
+      link_domain: 'github.com',
+    });
+  });
+
+  it('trims the link text', () => {
+    expect(linkFields('https://example.com/', '  Read more  ').link_text).toBe(
+      'Read more',
+    );
+  });
+
+  it('falls back to an empty domain for a non-url href', () => {
+    expect(linkFields('mailto:hi@example.com', 'Email').link_domain).toBe('');
+  });
+});
+
+describe('isOutbound', () => {
+  const host = 'olivierwinkler.com';
+
+  it('is true for an http(s) link on a different host', () => {
+    expect(isOutbound('https://github.com/owieth', host)).toBe(true);
+  });
+
+  it('is false for a link on the current host', () => {
+    expect(isOutbound(`https://${host}/projects`, host)).toBe(false);
+  });
+
+  it('is false for mailto, tel and non-http schemes', () => {
+    expect(isOutbound('mailto:hi@example.com', host)).toBe(false);
+    expect(isOutbound('tel:+123456789', host)).toBe(false);
+  });
+
+  it('is false for a malformed or relative href', () => {
+    expect(isOutbound('/projects', host)).toBe(false);
+    expect(isOutbound('#section', host)).toBe(false);
+  });
+});

--- a/src/lib/analytics/links.ts
+++ b/src/lib/analytics/links.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared anchor helpers for the click-tracking layer. Kept as pure string
+ * functions (no DOM types) so they run in the `node` vitest environment; the
+ * React chokepoints and the document delegate feed them `anchor.href` (already
+ * absolute), `anchor.textContent`, and `window.location.host`.
+ */
+
+/**
+ * Stamped on every anchor whose click a React handler already tracks. The
+ * document-level `OutboundLinkDelegate` skips anchors carrying it, so a normal
+ * outbound click never fires twice — once from the component, once from the
+ * delegate.
+ */
+export const ANALYTICS_HANDLED_ATTR = 'data-analytics-handled';
+
+export const handledMarker = { [ANALYTICS_HANDLED_ATTR]: '' } as const;
+
+export type LinkFields = {
+  link_url: string;
+  link_text: string;
+  link_domain: string;
+};
+
+/**
+ * The `link_url` / `link_text` / `link_domain` triple shared by the link-click
+ * events. `href` is expected absolute (the DOM resolves `anchor.href`); a
+ * non-URL `href` (e.g. `mailto:`) falls back to an empty domain rather than
+ * throwing.
+ */
+export const linkFields = (href: string, text: string): LinkFields => {
+  let link_domain = '';
+
+  try {
+    link_domain = new URL(href).hostname;
+  } catch {
+    link_domain = '';
+  }
+
+  return { link_url: href, link_text: text.trim(), link_domain };
+};
+
+/**
+ * True only for http(s) links pointing at a different host than the current
+ * one. `mailto:`, `tel:`, in-page hashes, and malformed hrefs are not outbound.
+ */
+export const isOutbound = (href: string, currentHost: string): boolean => {
+  try {
+    const url = new URL(href);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+    return url.host !== currentHost;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary

Instruments the site's click surfaces so link, navigation, download, citation and 404 events flow through the existing typed analytics contract. Stacks on the merged `page_view` layer, adding one union member per event rather than inventing new push shapes.

## Changes

- **Event contract** (`src/lib/analytics/events.ts`): Add `outbound_click`, `internal_link_click`, `nav_click`, `project_cta_click`, `download_click`, `citation_click` and `page_not_found` to the `AnalyticsEvent` union.
- **Shared helpers** (`src/lib/analytics/links.ts`): Add pure `linkFields`/`isOutbound` helpers and a `handledMarker` attribute, shared by the React chokepoints and the document delegate to dedupe outbound clicks.
- **Link & nav clicks**: `CustomLink` emits `outbound_click`/`internal_link_click` (and `nav_click` for the footer's Pages links via a new `nav` prop); `Header` nav items emit `nav_click`.
- **Project CTAs**: `ProjectLinks` emits `project_cta_click`, plus `download_click` for the GitHub release buttons; case-study pages pass the project `slug`.
- **Citations**: Extract the citation anchor into a client `Citation` component emitting `citation_click`; `Prose` re-exports `A` so its other elements stay server-rendered.
- **Remote `/design` MDX**: Add `OutboundLinkDelegate`, a document-level click listener that tracks raw outbound anchors, skipping React-handled ones via the marker so a click never fires twice.
- **404s**: Add `PageNotFoundTracker` on the not-found boundary, emitting `page_not_found` with the attempted path and referrer.
- **Tests**: Cover `linkFields`/`isOutbound` and the new event shapes.

## Additional Notes

- The three server chokepoints (`CustomLink`, `ProjectLinks`, `Citation`) become client components, as `onClick` requires a client boundary.
- Download buttons emit both `project_cta_click` and `download_click` by design.
- `src/components/Dock.tsx` is left uninstrumented (dead code, per the issue).

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)