### PR TITLE
feat(analytics): send server events via the Measurement Protocol

### DIFF
--- a/src/app/(site)/design/page.tsx
+++ b/src/app/(site)/design/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
 import { MDXRemote } from 'next-mdx-remote/rsc';
+import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
+
+import { trackServer } from '@/lib/analytics/server/track-server';
 
 export const metadata: Metadata = {
   title: 'Design',
@@ -12,12 +15,21 @@ export const metadata: Metadata = {
 };
 
 export default async function DesignPage() {
+  // Reading the cookie attaches the failure event to the visitor's session, at
+  // the cost of opting the page render out of ISR; the GitHub fetch below keeps
+  // its own `revalidate` cache regardless.
+  const cookieHeader = (await cookies()).toString();
+
   const res = await fetch(
     'https://raw.githubusercontent.com/owieth/designs/main/README.md',
     { next: { revalidate: 3600 } },
   );
 
   if (!res.ok) {
+    trackServer(
+      { name: 'design_fetch_failed_server', status: res.status },
+      cookieHeader,
+    );
     notFound();
   }
 

--- a/src/app/api/wo-haere/og/route.tsx
+++ b/src/app/api/wo-haere/og/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og';
 
+import { trackServer } from '@/lib/analytics/server/track-server';
 import { APP, RESULTAT, kantonsName } from '@/lib/wo-haere/data/bern';
 import { resolveHit } from '@/lib/wo-haere/geo/resolveHit';
 import { noechschtsZiu } from '@/lib/wo-haere/reactions';
@@ -10,15 +11,18 @@ export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
 export async function GET(request: Request) {
+  const cookieHeader = request.headers.get('cookie');
   const wurfParam = parseWurf(new URL(request.url).searchParams.get('wurf'));
 
   let titu: string = APP.name;
   let underTitu: string = APP.tagline;
   let zeile = '';
+  let resolved = false;
 
   if (wurfParam) {
     try {
       const wurf = await resolveHit(wurfParam);
+      resolved = wurf.art === 'preich';
       if (wurf.art === 'preich') {
         const nz = noechschtsZiu(wurfParam);
         titu = nz?.ziu.name ?? wurf.gmeind;
@@ -35,6 +39,14 @@ export async function GET(request: Request) {
       // Fall back to the generic card rather than failing the image.
     }
   }
+
+  // Fires on every request, so crawlers and unfurl bots inflate it; most such
+  // hits carry no `_ga` cookie and land as `client_source: 'synthetic'`. Read
+  // it as a noisy share-reach proxy, not a clean count.
+  trackServer(
+    { name: 'og_unfurl_server', has_wurf: Boolean(wurfParam), resolved },
+    cookieHeader,
+  );
 
   return new ImageResponse(
     <div

--- a/src/app/api/wo-haere/wurf/route.ts
+++ b/src/app/api/wo-haere/wurf/route.ts
@@ -1,3 +1,4 @@
+import { trackServer } from '@/lib/analytics/server/track-server';
 import { resolveHit } from '@/lib/wo-haere/geo/resolveHit';
 
 export const runtime = 'nodejs';
@@ -31,10 +32,44 @@ export async function POST(request: Request) {
     );
   }
 
+  const cookieHeader = request.headers.get('cookie');
+  const start = performance.now();
+
   try {
-    return Response.json(await resolveHit({ lat, lon }));
+    const wurf = await resolveHit({ lat, lon });
+    const upstream_ms = Math.round(performance.now() - start);
+
+    trackServer(
+      wurf.art === 'preich'
+        ? {
+            name: 'throw_resolved_server',
+            art: wurf.art,
+            upstream_ms,
+            kanton: wurf.kanton,
+            wasser: wurf.wasser,
+            distanz_km: Math.round(wurf.distanzKm),
+            richtig: wurf.richtig,
+            ...(wurf.hoechi !== null ? { hoechi: wurf.hoechi } : {}),
+          }
+        : {
+            name: 'throw_resolved_server',
+            art: wurf.art,
+            upstream_ms,
+            grund: wurf.grund,
+          },
+      cookieHeader,
+    );
+
+    return Response.json(wurf);
   } catch (error) {
     console.error('resolveHit failed', error);
+    trackServer(
+      {
+        name: 'swisstopo_error_server',
+        upstream_ms: Math.round(performance.now() - start),
+      },
+      cookieHeader,
+    );
     return Response.json(
       { fähler: 'swisstopo git grad nid Antwort' },
       { status: 502 },

--- a/src/lib/analytics/config.ts
+++ b/src/lib/analytics/config.ts
@@ -1,17 +1,20 @@
 /**
- * Env reads for the analytics layer. No zod — the surface is three strings and
- * a boolean, and the whole layer no-ops when they are unset, so a validation
- * dependency would buy nothing.
+ * Env reads for the analytics layer. No zod — the surface is a handful of
+ * strings and two booleans, and the whole layer no-ops when they are unset, so
+ * a validation dependency would buy nothing.
  *
  * `GTM_ID` and `GA_ID` are public (`NEXT_PUBLIC_`) because the browser needs
- * them. `GA4_API_SECRET` is server-only (Measurement Protocol, a later layer)
- * and is deliberately not read here — see `.env.example`. `SITE_URL` lives in
- * `@/lib/site`.
+ * them. `GA4_API_SECRET` is server-only and powers the GA4 Measurement Protocol
+ * layer (see `@/lib/analytics/server`); `GA_ID` doubles as its `measurement_id`.
+ * `SITE_URL` lives in `@/lib/site`.
  *
- * Unset ⇒ `isAnalyticsEnabled` is false ⇒ no GTM script renders and `track()`
- * only logs to the console, so dev and CI stay silent.
+ * Unset ⇒ the matching `is…Enabled` flag is false ⇒ no GTM script renders,
+ * `track()` only logs to the console, and the server layer skips its POST, so
+ * dev and CI stay silent.
  */
 export const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID ?? '';
 export const GA_ID = process.env.NEXT_PUBLIC_GA_ID ?? '';
+export const GA4_API_SECRET = process.env.GA4_API_SECRET ?? '';
 
 export const isAnalyticsEnabled = Boolean(GTM_ID && GA_ID);
+export const isServerAnalyticsEnabled = Boolean(GA_ID && GA4_API_SECRET);

--- a/src/lib/analytics/server/measurement-protocol.test.ts
+++ b/src/lib/analytics/server/measurement-protocol.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `config` reads the env at module load, so toggling the server layer on/off
+ * means re-importing after stubbing the env — the same pattern `track.test.ts`
+ * uses. The Measurement Protocol module deliberately avoids `next/server`, so it
+ * imports cleanly in the node test environment without a request context.
+ */
+const GA_ID = 'G-TESTSTREAM';
+const STREAM = 'TESTSTREAM';
+const API_SECRET = 'secret-123';
+
+const importModule = async () => {
+  vi.resetModules();
+  return import('@/lib/analytics/server/measurement-protocol');
+};
+
+const enableServer = () => {
+  vi.stubEnv('NEXT_PUBLIC_GA_ID', GA_ID);
+  vi.stubEnv('GA4_API_SECRET', API_SECRET);
+};
+
+beforeEach(() => {
+  enableServer();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('parseClientId', () => {
+  it('extracts the trailing client id from a well-formed _ga cookie', async () => {
+    const { parseClientId } = await importModule();
+
+    expect(parseClientId('_ga=GA1.1.1234567890.1700000000')).toBe(
+      '1234567890.1700000000',
+    );
+  });
+
+  it('returns null for a malformed _ga cookie', async () => {
+    const { parseClientId } = await importModule();
+
+    expect(parseClientId('_ga=broken')).toBeNull();
+    expect(parseClientId('_ga=GA1.1.')).toBeNull();
+  });
+
+  it('returns null when the _ga cookie is absent', async () => {
+    const { parseClientId } = await importModule();
+
+    expect(parseClientId('other=1')).toBeNull();
+    expect(parseClientId(null)).toBeNull();
+  });
+});
+
+describe('parseSessionId', () => {
+  it('reads the session id from the GS2 stream cookie', async () => {
+    const { parseSessionId } = await importModule();
+
+    expect(parseSessionId(`_ga_${STREAM}=GS2.1.s1700000000$o5$g1`)).toBe(
+      '1700000000',
+    );
+  });
+
+  it('reads the older GS1 stream format', async () => {
+    const { parseSessionId } = await importModule();
+
+    expect(parseSessionId(`_ga_${STREAM}=GS1.1.1700000000.5.1`)).toBe(
+      '1700000000',
+    );
+  });
+
+  it('returns null when the stream cookie is absent', async () => {
+    const { parseSessionId } = await importModule();
+
+    expect(parseSessionId('_ga=GA1.1.10.20')).toBeNull();
+    expect(parseSessionId(null)).toBeNull();
+  });
+});
+
+describe('deriveClientId', () => {
+  it('tags a cookie-derived id', async () => {
+    const { deriveClientId } = await importModule();
+
+    expect(deriveClientId('_ga=GA1.1.10.20')).toEqual({
+      clientId: '10.20',
+      clientSource: 'cookie',
+    });
+  });
+
+  it('falls back to a synthetic id when there is no cookie', async () => {
+    const { deriveClientId } = await importModule();
+
+    const result = deriveClientId(null);
+
+    expect(result.clientSource).toBe('synthetic');
+    expect(result.clientId.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildPayload', () => {
+  const cookieHeader = `_ga=GA1.1.10.20; _ga_${STREAM}=GS2.1.s999$o1`;
+
+  it('nests event params with session_id and engagement_time_msec', async () => {
+    const { buildPayload } = await importModule();
+
+    expect(
+      buildPayload(
+        { name: 'og_unfurl_server', has_wurf: true, resolved: false },
+        cookieHeader,
+      ),
+    ).toEqual({
+      client_id: '10.20',
+      events: [
+        {
+          name: 'og_unfurl_server',
+          params: {
+            has_wurf: true,
+            resolved: false,
+            session_id: '999',
+            engagement_time_msec: 1,
+            client_source: 'cookie',
+          },
+        },
+      ],
+    });
+  });
+
+  it('omits session_id when the stream cookie is missing', async () => {
+    const { buildPayload } = await importModule();
+
+    const payload = buildPayload(
+      { name: 'design_fetch_failed_server', status: 503 },
+      '_ga=GA1.1.10.20',
+    );
+
+    expect(payload.events[0].params).not.toHaveProperty('session_id');
+    expect(payload.events[0].params.engagement_time_msec).toBe(1);
+  });
+
+  it('keeps the _server suffix as the event name and tags synthetic clients', async () => {
+    const { buildPayload } = await importModule();
+
+    const payload = buildPayload(
+      { name: 'swisstopo_error_server', upstream_ms: 12 },
+      null,
+    );
+
+    expect(payload.events[0].name).toBe('swisstopo_error_server');
+    expect(payload.events[0].params.client_source).toBe('synthetic');
+  });
+});
+
+describe('sendMeasurementProtocolEvent', () => {
+  it('POSTs to the MP endpoint with measurement_id and api_secret', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { sendMeasurementProtocolEvent } = await importModule();
+
+    await sendMeasurementProtocolEvent(
+      { name: 'swisstopo_error_server', upstream_ms: 5 },
+      '_ga=GA1.1.10.20',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    const parsed = new URL(url);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      'https://www.google-analytics.com/mp/collect',
+    );
+    expect(parsed.searchParams.get('measurement_id')).toBe(GA_ID);
+    expect(parsed.searchParams.get('api_secret')).toBe(API_SECRET);
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string).events[0].name).toBe(
+      'swisstopo_error_server',
+    );
+  });
+
+  it('never rejects when fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new Error('network down'))),
+    );
+    const { sendMeasurementProtocolEvent } = await importModule();
+
+    await expect(
+      sendMeasurementProtocolEvent(
+        { name: 'swisstopo_error_server', upstream_ms: 5 },
+        null,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('no-ops when the server layer is disabled', async () => {
+    vi.stubEnv('GA4_API_SECRET', '');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { sendMeasurementProtocolEvent } = await importModule();
+
+    await sendMeasurementProtocolEvent(
+      { name: 'swisstopo_error_server', upstream_ms: 5 },
+      null,
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analytics/server/measurement-protocol.ts
+++ b/src/lib/analytics/server/measurement-protocol.ts
@@ -1,0 +1,188 @@
+import {
+  GA4_API_SECRET,
+  GA_ID,
+  isServerAnalyticsEnabled,
+} from '@/lib/analytics/config';
+import { MAX_EVENT_NAME_LENGTH, MAX_EVENT_PARAMS } from '@/lib/analytics/events';
+
+/**
+ * The server-side event contract, delivered to GA4 through the Measurement
+ * Protocol rather than the browser `dataLayer`. It is a union of its own — a
+ * server event can never travel through client `track()` (no `window`), so the
+ * two layers keep separate vocabularies while sharing the GA4 limit constants.
+ *
+ * Every name carries the `_server` suffix so these can never double-count the
+ * client events. `name` becomes the GA4 event name; the remaining keys become
+ * GA4 event parameters (joined with the MP-required params in `buildPayload`).
+ */
+export type ThrowResolvedServerEvent = {
+  name: 'throw_resolved_server';
+  art: string;
+  upstream_ms: number;
+  kanton?: string;
+  wasser?: boolean;
+  hoechi?: number;
+  distanz_km?: number;
+  richtig?: string;
+  grund?: string;
+};
+
+export type SwisstopoErrorServerEvent = {
+  name: 'swisstopo_error_server';
+  upstream_ms: number;
+};
+
+export type OgUnfurlServerEvent = {
+  name: 'og_unfurl_server';
+  has_wurf: boolean;
+  resolved: boolean;
+};
+
+export type DesignFetchFailedServerEvent = {
+  name: 'design_fetch_failed_server';
+  status: number;
+};
+
+export type ServerAnalyticsEvent =
+  | ThrowResolvedServerEvent
+  | SwisstopoErrorServerEvent
+  | OgUnfurlServerEvent
+  | DesignFetchFailedServerEvent;
+
+const MP_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+/**
+ * GA4 accepts an MP hit without `session_id`/`engagement_time_msec` (a 204) and
+ * then drops it from most reports — the quietest possible failure. A small
+ * positive value keeps the hit reportable without inventing engagement.
+ */
+const ENGAGEMENT_TIME_MSEC = 1;
+
+export type ClientSource = 'cookie' | 'synthetic';
+
+const parseCookieHeader = (
+  cookieHeader: string | null | undefined,
+): Record<string, string> => {
+  if (!cookieHeader) return {};
+
+  const map: Record<string, string> = {};
+  for (const part of cookieHeader.split(';')) {
+    const index = part.indexOf('=');
+    if (index === -1) continue;
+    const key = part.slice(0, index).trim();
+    if (key) map[key] = part.slice(index + 1).trim();
+  }
+  return map;
+};
+
+/**
+ * The GA `_ga` cookie is `GA1.1.<a>.<b>`; GA4's client_id is the trailing
+ * `<a>.<b>`. A missing or truncated value yields null so the caller falls back
+ * to a synthetic id — the difference is what `client_source` records.
+ */
+export const parseClientId = (
+  cookieHeader: string | null | undefined,
+): string | null => {
+  const value = parseCookieHeader(cookieHeader)._ga;
+  const match = value?.match(/^GA\d+\.\d+\.(\d+\.\d+)$/);
+  return match ? match[1] : null;
+};
+
+/** The stream cookie is named after the measurement id minus its `G-` prefix. */
+const streamCookieName = (): string => `_ga_${GA_ID.replace(/^G-/, '')}`;
+
+/**
+ * The `_ga_<STREAM>` cookie is `GS2.1.s<session_id>$…`; older browsers write
+ * `GS1.1.<session_id>.…`. Both put the session id first, so one pattern reads
+ * either. Missing ⇒ null, and the event ships without the param.
+ */
+export const parseSessionId = (
+  cookieHeader: string | null | undefined,
+): string | null => {
+  const value = parseCookieHeader(cookieHeader)[streamCookieName()];
+  const match = value?.match(/^GS\d+\.\d+\.s?(\d+)/);
+  return match ? match[1] : null;
+};
+
+/**
+ * A cookie-derived id attaches the event to the session that caused it; the
+ * synthetic fallback covers crawlers and unfurl bots with no `_ga` cookie, and
+ * `client_source` keeps the two apart in reporting.
+ */
+export const deriveClientId = (
+  cookieHeader: string | null | undefined,
+): { clientId: string; clientSource: ClientSource } => {
+  const fromCookie = parseClientId(cookieHeader);
+  return fromCookie
+    ? { clientId: fromCookie, clientSource: 'cookie' }
+    : { clientId: crypto.randomUUID(), clientSource: 'synthetic' };
+};
+
+/**
+ * GA4 silently drops an event whose name exceeds 40 characters or that carries
+ * more than 25 parameters. Mirrors client `isValidEvent`, reusing the same
+ * pinned limits.
+ */
+export const isValidServerEvent = (event: ServerAnalyticsEvent): boolean => {
+  const paramCount = Object.keys(event).filter(key => key !== 'name').length;
+
+  return (
+    event.name.length <= MAX_EVENT_NAME_LENGTH && paramCount <= MAX_EVENT_PARAMS
+  );
+};
+
+export type MeasurementProtocolPayload = {
+  client_id: string;
+  events: { name: string; params: Record<string, unknown> }[];
+};
+
+export const buildPayload = (
+  event: ServerAnalyticsEvent,
+  cookieHeader: string | null | undefined,
+): MeasurementProtocolPayload => {
+  const { name, ...eventParams } = event;
+  const { clientId, clientSource } = deriveClientId(cookieHeader);
+  const sessionId = parseSessionId(cookieHeader);
+
+  const params: Record<string, unknown> = {
+    ...eventParams,
+    engagement_time_msec: ENGAGEMENT_TIME_MSEC,
+    client_source: clientSource,
+  };
+  if (sessionId) params.session_id = sessionId;
+
+  return { client_id: clientId, events: [{ name, params }] };
+};
+
+/**
+ * The MP POST itself. Pure and awaitable (so it can be unit-tested without a
+ * request context); the `after()` scheduling that keeps it off the response
+ * path lives in `track-server.ts`. No-ops when the server layer is unconfigured
+ * and swallows every network error — telemetry must never surface in a route.
+ */
+export const sendMeasurementProtocolEvent = async (
+  event: ServerAnalyticsEvent,
+  cookieHeader: string | null | undefined,
+): Promise<void> => {
+  if (!isServerAnalyticsEnabled) return;
+
+  if (process.env.NODE_ENV !== 'production' && !isValidServerEvent(event)) {
+    console.warn(
+      '[analytics] server event exceeds GA4 limits, will be dropped',
+      event,
+    );
+  }
+
+  const url = `${MP_ENDPOINT}?measurement_id=${encodeURIComponent(
+    GA_ID,
+  )}&api_secret=${encodeURIComponent(GA4_API_SECRET)}`;
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      body: JSON.stringify(buildPayload(event, cookieHeader)),
+    });
+  } catch {
+    // Fire-and-forget: a failed telemetry POST must never reach the route.
+  }
+};

--- a/src/lib/analytics/server/track-server.ts
+++ b/src/lib/analytics/server/track-server.ts
@@ -1,0 +1,30 @@
+import { after } from 'next/server';
+
+import { isServerAnalyticsEnabled } from '@/lib/analytics/config';
+import {
+  sendMeasurementProtocolEvent,
+  type ServerAnalyticsEvent,
+} from '@/lib/analytics/server/measurement-protocol';
+
+/**
+ * The single entry point routes and Server Components use to emit a server
+ * event. `after()` runs the Measurement Protocol POST once the response has
+ * flushed, so it never blocks the handler and the function stays alive long
+ * enough to send it on Vercel Fluid Compute.
+ *
+ * Mirrors client `track()`: when the server layer is unconfigured (env unset)
+ * it logs to the console instead of firing, keeping dev and CI silent. The
+ * `after` import is isolated here so `measurement-protocol.ts` stays importable
+ * in the node test environment without a request context.
+ */
+export const trackServer = (
+  event: ServerAnalyticsEvent,
+  cookieHeader: string | null | undefined,
+): void => {
+  if (!isServerAnalyticsEnabled) {
+    console.debug('[analytics]', event);
+    return;
+  }
+
+  after(() => sendMeasurementProtocolEvent(event, cookieHeader));
+};


### PR DESCRIPTION
Adds a server-only GA4 Measurement Protocol layer that captures the honest upstream picture the client can't see: resolved throws and swisstopo 502s from `POST /api/wo-haere/wurf`, unfurls from the OG route, and the previously silent GitHub failure on `/design`. Delivery is fire-and-forget — the POST is scheduled via `after()` so it never blocks the response or throws into a route — and it parses `client_id`/`session_id` off the `_ga` cookies, falling back to a synthetic client for cookieless crawlers while always sending `engagement_time_msec` so hits stay reportable. Every event name carries a `_server` suffix so it can never double-count the client layer, and the layer no-ops until `GA4_API_SECRET` is set. Reading the cookie on `/design` opts its render out of ISR by design; the GitHub fetch keeps its own revalidate cache. Part of #397, closes #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)