### PR TITLE
feat(analytics): derive GA4 user properties and tag internal traffic

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import AnalyticsScripts from '@/components/analytics/AnalyticsScripts';
 import PageViewTracker from '@/components/analytics/PageViewTracker';
+import UserPropertiesTracker from '@/components/analytics/UserPropertiesTracker';
 import { SITE_URL } from '@/lib/site';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -101,6 +102,7 @@ export default function RootLayout({
         />
         {children}
         <PageViewTracker />
+        <UserPropertiesTracker />
         <Analytics />
         <SpeedInsights />
       </body>

--- a/src/components/analytics/UserPropertiesTracker.tsx
+++ b/src/components/analytics/UserPropertiesTracker.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { syncInternalTrafficFlag } from '@/lib/analytics/internal-traffic';
+import {
+  buildUserProperties,
+  setUserProperties,
+} from '@/lib/analytics/user-properties';
+import { useWoHaere } from '@/lib/wo-haere/store';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+
+/**
+ * Keeps the two device-side analytics signals in sync, without any UI:
+ *
+ *   - the internal-traffic flag, toggled from the `?ow_internal` query param;
+ *   - the GA4 user properties derived from the wo-haere throw log and device
+ *     context, re-set whenever the throw log changes so counts grow live within
+ *     a session.
+ */
+const UserPropertiesTrackerInner = () => {
+  const searchParams = useSearchParams();
+  const { wurfbuech } = useWoHaere();
+
+  useEffect(() => {
+    syncInternalTrafficFlag(searchParams.toString());
+  }, [searchParams]);
+
+  useEffect(() => {
+    setUserProperties(buildUserProperties(wurfbuech));
+  }, [wurfbuech]);
+
+  return null;
+};
+
+/**
+ * `useSearchParams` opts a route into client-side rendering unless it sits under
+ * a Suspense boundary, so the tracker is wrapped here to keep the rest of the
+ * tree server-rendered (mirrors `PageViewTracker`).
+ */
+const UserPropertiesTracker = () => (
+  <Suspense fallback={null}>
+    <UserPropertiesTrackerInner />
+  </Suspense>
+);
+
+export default UserPropertiesTracker;

--- a/src/lib/analytics/internal-traffic.test.ts
+++ b/src/lib/analytics/internal-traffic.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isInternalTraffic,
+  syncInternalTrafficFlag,
+} from '@/lib/analytics/internal-traffic';
+
+const makeStorage = (initial: Record<string, string> = {}) => {
+  const store: Record<string, string> = { ...initial };
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+  };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('internal-traffic', () => {
+  it('sets the flag on ?ow_internal=1', () => {
+    const localStorage = makeStorage();
+    vi.stubGlobal('window', { localStorage });
+
+    syncInternalTrafficFlag('ow_internal=1');
+
+    expect(localStorage.getItem('ow_internal')).toBe('1');
+    expect(isInternalTraffic()).toBe(true);
+  });
+
+  it('clears the flag on ?ow_internal=0', () => {
+    const localStorage = makeStorage({ ow_internal: '1' });
+    vi.stubGlobal('window', { localStorage });
+
+    syncInternalTrafficFlag('ow_internal=0');
+
+    expect(localStorage.getItem('ow_internal')).toBeNull();
+    expect(isInternalTraffic()).toBe(false);
+  });
+
+  it('leaves an existing flag untouched when the param is absent', () => {
+    const localStorage = makeStorage({ ow_internal: '1' });
+    vi.stubGlobal('window', { localStorage });
+
+    syncInternalTrafficFlag('foo=bar');
+
+    expect(isInternalTraffic()).toBe(true);
+  });
+
+  it('is false on the server, where there is no window', () => {
+    expect(isInternalTraffic()).toBe(false);
+  });
+});

--- a/src/lib/analytics/internal-traffic.ts
+++ b/src/lib/analytics/internal-traffic.ts
@@ -1,0 +1,42 @@
+/**
+ * Internal-traffic tagging. On a low-traffic personal site the owner's own
+ * visits otherwise dominate every number, and there's no reliable IP filter
+ * (home IP breaks on mobile data). So the owner marks their own device once:
+ * visiting `?ow_internal=1` sets a localStorage flag, after which `track()`
+ * attaches `traffic_type: 'internal'` to every event and GA4's built-in
+ * internal-traffic data filter can exclude them. `?ow_internal=0` clears it.
+ */
+const INTERNAL_TRAFFIC_KEY = 'ow_internal';
+const INTERNAL_TRAFFIC_PARAM = 'ow_internal';
+
+/**
+ * Reads the `ow_internal` query param and toggles the persisted flag: `1` sets,
+ * `0` clears, anything else (including absence) leaves it untouched — so a plain
+ * navigation never disturbs a device that was already marked.
+ */
+export const syncInternalTrafficFlag = (search: string): void => {
+  if (typeof window === 'undefined') return;
+
+  const value = new URLSearchParams(search).get(INTERNAL_TRAFFIC_PARAM);
+  if (value !== '1' && value !== '0') return;
+
+  try {
+    if (value === '1') {
+      window.localStorage.setItem(INTERNAL_TRAFFIC_KEY, '1');
+    } else {
+      window.localStorage.removeItem(INTERNAL_TRAFFIC_KEY);
+    }
+  } catch {
+    // A full or blocked localStorage must never break a navigation.
+  }
+};
+
+export const isInternalTraffic = (): boolean => {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(INTERNAL_TRAFFIC_KEY) === '1';
+  } catch {
+    return false;
+  }
+};

--- a/src/lib/analytics/track.test.ts
+++ b/src/lib/analytics/track.test.ts
@@ -76,4 +76,17 @@ describe('track', () => {
 
     expect(window.dataLayer).toHaveLength(2);
   });
+
+  it('tags the event as internal traffic when the flag is set', async () => {
+    enableAnalytics();
+    grantConsent();
+    vi.stubGlobal('window', { localStorage: { getItem: () => '1' } });
+    const track = await importTrack();
+
+    track(pageView);
+
+    expect(window.dataLayer).toEqual([
+      { event: 'page_view', page_path: '/', traffic_type: 'internal' },
+    ]);
+  });
 });

--- a/src/lib/analytics/track.ts
+++ b/src/lib/analytics/track.ts
@@ -1,6 +1,7 @@
 import { isAnalyticsEnabled } from '@/lib/analytics/config';
 import { resolveConsent } from '@/lib/analytics/consent';
 import { isValidEvent, type AnalyticsEvent } from '@/lib/analytics/events';
+import { isInternalTraffic } from '@/lib/analytics/internal-traffic';
 
 declare global {
   interface Window {
@@ -32,11 +33,18 @@ export const track = (event: AnalyticsEvent): void => {
   if (typeof window === 'undefined') return;
 
   if (process.env.NODE_ENV !== 'production' && !isValidEvent(event)) {
-    console.warn('[analytics] event exceeds GA4 limits, will be dropped', event);
+    console.warn(
+      '[analytics] event exceeds GA4 limits, will be dropped',
+      event,
+    );
   }
 
   const { name, ...params } = event;
 
   window.dataLayer ??= [];
-  window.dataLayer.push({ event: name, ...params });
+  window.dataLayer.push({
+    event: name,
+    ...params,
+    ...(isInternalTraffic() && { traffic_type: 'internal' }),
+  });
 };

--- a/src/lib/analytics/user-properties.test.ts
+++ b/src/lib/analytics/user-properties.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { UserProperties } from '@/lib/analytics/user-properties';
+import type { WurfEintrag } from '@/lib/wo-haere/types';
+
+/**
+ * `config` reads the env at module load, so toggling analytics on/off means
+ * re-importing the module after stubbing the env (mirrors `track.test.ts`).
+ */
+const importModule = async () => {
+  vi.resetModules();
+  return import('@/lib/analytics/user-properties');
+};
+
+const enableAnalytics = () => {
+  vi.stubEnv('NEXT_PUBLIC_GTM_ID', 'GTM-TEST');
+  vi.stubEnv('NEXT_PUBLIC_GA_ID', 'G-TEST');
+};
+
+const matchMedia = (matches: Record<string, boolean>) => (query: string) => ({
+  matches: Boolean(matches[query]),
+});
+
+const preich = (kanton: string): WurfEintrag => ({
+  id: kanton,
+  zyt: 0,
+  ziuName: null,
+  isPreich: true,
+  wurf: {
+    art: 'preich',
+    lat: 0,
+    lon: 0,
+    gmeind: '',
+    kanton,
+    gdeNr: null,
+    hoechi: null,
+    wasser: false,
+    distanzKm: 0,
+    richtig: '',
+  },
+});
+
+const dernaebe = (): WurfEintrag => ({
+  id: 'miss',
+  zyt: 0,
+  ziuName: null,
+  isPreich: false,
+  wurf: { art: 'dernaebe', grund: 'usland', lat: 0, lon: 0 },
+});
+
+const SAMPLE: UserProperties = {
+  throw_count: 3,
+  cantons_collected: 2,
+  dart_skins_unlocked: 1,
+  color_scheme: 'light',
+  reduced_motion: false,
+  pointer_type: 'fine',
+};
+
+beforeEach(() => {
+  vi.stubGlobal('document', { cookie: '' });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('buildUserProperties', () => {
+  it('derives game counts and device context from the throw log', async () => {
+    vi.stubGlobal('window', {
+      matchMedia: matchMedia({
+        '(prefers-color-scheme: dark)': true,
+        '(pointer: fine)': true,
+      }),
+    });
+    const { buildUserProperties } = await importModule();
+
+    const props = buildUserProperties([
+      preich('BE'),
+      preich('BE'),
+      preich('ZH'),
+      dernaebe(),
+      dernaebe(),
+    ]);
+
+    expect(props).toEqual({
+      throw_count: 5,
+      cantons_collected: 2,
+      dart_skins_unlocked: 2, // 5 throws unlocks the 0- and 5-throw skins
+      color_scheme: 'dark',
+      reduced_motion: false,
+      pointer_type: 'fine',
+    });
+  });
+
+  it('reports zeroes and safe defaults for an empty log', async () => {
+    vi.stubGlobal('window', { matchMedia: matchMedia({}) });
+    const { buildUserProperties } = await importModule();
+
+    const props = buildUserProperties([]);
+
+    expect(props).toEqual({
+      throw_count: 0,
+      cantons_collected: 0,
+      dart_skins_unlocked: 1, // the 0-throw default skin is always unlocked
+      color_scheme: 'light',
+      reduced_motion: false,
+      pointer_type: 'none',
+    });
+  });
+});
+
+describe('setUserProperties', () => {
+  it('no-ops and logs to the console when analytics is disabled', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GTM_ID', '');
+    vi.stubEnv('NEXT_PUBLIC_GA_ID', '');
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.stubGlobal('window', {});
+    const { setUserProperties } = await importModule();
+
+    setUserProperties(SAMPLE);
+
+    expect(debug).toHaveBeenCalledWith('[analytics] user_properties', SAMPLE);
+    expect(window.dataLayer).toBeUndefined();
+  });
+
+  it('no-ops when analytics consent is denied', async () => {
+    enableAnalytics();
+    vi.stubGlobal('navigator', { globalPrivacyControl: true });
+    vi.stubGlobal('window', {});
+    const { setUserProperties } = await importModule();
+
+    setUserProperties(SAMPLE);
+
+    expect(window.dataLayer).toBeUndefined();
+  });
+
+  it('pushes the properties to the dataLayer when enabled and granted', async () => {
+    enableAnalytics();
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('window', {});
+    const { setUserProperties } = await importModule();
+
+    setUserProperties(SAMPLE);
+
+    expect(window.dataLayer).toEqual([
+      { event: 'set_user_properties', user_properties: SAMPLE },
+    ]);
+  });
+});

--- a/src/lib/analytics/user-properties.ts
+++ b/src/lib/analytics/user-properties.ts
@@ -1,0 +1,79 @@
+import { isAnalyticsEnabled } from '@/lib/analytics/config';
+import { resolveConsent } from '@/lib/analytics/consent';
+import { PFYLSORTE } from '@/lib/wo-haere/data/bern';
+import { prefersReducedMotion } from '@/lib/wo-haere/motion';
+import { gsammleteKantöne } from '@/lib/wo-haere/store';
+import type { WurfEintrag } from '@/lib/wo-haere/types';
+
+/**
+ * GA4 user properties, derived entirely from state the site already keeps — the
+ * wo-haere throw log (localStorage) plus the browser's own device signals. No
+ * new storage, no new tracking; they just turn every other event into something
+ * segmentable by how engaged the visitor already is (first-throw vs 30th-throw
+ * behaviour) and by their device context.
+ *
+ * GA4 caps user-property names at 24 chars and values at 36; the six below stay
+ * well inside both, and six is far under the 25-property limit.
+ */
+export type UserProperties = {
+  throw_count: number;
+  cantons_collected: number;
+  dart_skins_unlocked: number;
+  color_scheme: 'light' | 'dark';
+  reduced_motion: boolean;
+  pointer_type: 'coarse' | 'fine' | 'none';
+};
+
+const colorScheme = (): UserProperties['color_scheme'] => {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+};
+
+const pointerType = (): UserProperties['pointer_type'] => {
+  if (typeof window === 'undefined') return 'none';
+  if (window.matchMedia('(pointer: fine)').matches) return 'fine';
+  if (window.matchMedia('(pointer: coarse)').matches) return 'coarse';
+  return 'none';
+};
+
+/**
+ * Pure over the throw log for the game-derived counts; the device fields read
+ * the current media queries at call time (mirrors `prefersReducedMotion`).
+ * `throw_count` is already capped at 200 by the store's `MAX_WUERF`.
+ */
+export const buildUserProperties = (
+  wurfbuech: WurfEintrag[],
+): UserProperties => ({
+  throw_count: wurfbuech.length,
+  cantons_collected: gsammleteKantöne(wurfbuech).size,
+  dart_skins_unlocked: PFYLSORTE.filter(s => wurfbuech.length >= s.abNWuerf)
+    .length,
+  color_scheme: colorScheme(),
+  reduced_motion: prefersReducedMotion(),
+  pointer_type: pointerType(),
+});
+
+/**
+ * Sets the GA4 user properties by pushing them onto the GTM `dataLayer`, where
+ * the container maps them onto the GA4 tag. Shares `track()`'s gating exactly:
+ * no-ops (with a console trail) when analytics is disabled, respects Consent
+ * Mode, and never touches `window` on the server.
+ */
+export const setUserProperties = (props: UserProperties): void => {
+  if (!isAnalyticsEnabled) {
+    console.debug('[analytics] user_properties', props);
+    return;
+  }
+
+  if (resolveConsent().analytics_storage !== 'granted') return;
+
+  if (typeof window === 'undefined') return;
+
+  window.dataLayer ??= [];
+  window.dataLayer.push({
+    event: 'set_user_properties',
+    user_properties: props,
+  });
+};


### PR DESCRIPTION
## Summary
Turn state the site already keeps into segmentation for free: the wo-haere throw log becomes GA4 user properties (so every event is comparable by how engaged a visitor is), and the owner can mark their own device to keep dev sessions out of the numbers on a low-traffic personal site.

## Changes
- **Tag internal traffic** — `src/lib/analytics/internal-traffic.ts`: `?ow_internal=1` sets a localStorage flag (`=0` clears it); `track()` then attaches `traffic_type: 'internal'` to every event for GA4's internal-traffic data filter.
- **Derive user properties** — `src/lib/analytics/user-properties.ts`: `buildUserProperties()` reads the throw log for `throw_count`, `cantons_collected` and `dart_skins_unlocked` (reusing `gsammleteKantöne`/`PFYLSORTE`) plus device context (`color_scheme`, `reduced_motion` via the existing `prefersReducedMotion`, `pointer_type`); `setUserProperties()` pushes them onto the dataLayer with the same enabled/consent/window gating as `track()`.
- **Wire it up** — `UserPropertiesTracker` (a Suspense-wrapped client island mirroring `PageViewTracker`) syncs the flag from the URL and re-sets user properties whenever the throw log changes; mounted in the root layout.
- **Tests** — new `internal-traffic.test.ts` and `user-properties.test.ts`, plus an internal-traffic case in `track.test.ts`.

## Additional Notes
No new state or storage is introduced — everything is derived. One out-of-repo step: the GTM container must map the `user_properties` dataLayer object onto the GA4 tag (`traffic_type` already flows through as a native event param).

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)