### PR TITLE
feat(security): add Report-Only Content-Security-Policy

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,22 @@
+/**
+ * Report-Only so a wrong allowlist logs violations to the console instead of
+ * breaking the site; flipping to the enforcing header is a follow-up. This
+ * constrains where resources may load from — it is not an inline-XSS defence:
+ * `script-src` keeps `'unsafe-inline'` because GTM injects inline scripts with
+ * no nonce and the layout ships an inline JSON-LD script.
+ */
+const contentSecurityPolicy = [
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+  "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://api3.geo.admin.ch https://wmts.geo.admin.ch https://tiles.openfreemap.org",
+  "img-src 'self' data: blob: https://*.google-analytics.com https://www.googletagmanager.com https://*.geo.admin.ch",
+  "worker-src 'self' blob:",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self'",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "object-src 'none'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
@@ -27,6 +46,10 @@ const nextConfig = {
           {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
+          },
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: contentSecurityPolicy,
           },
         ],
       },


### PR DESCRIPTION
## Summary

There is no `Content-Security-Policy` today — `next.config.js` sets five security headers and stops. Adding a third-party tag manager (GTM) is a reasonable moment to close that gap.

## Changes

- Add a `Content-Security-Policy-Report-Only` header in `next.config.js`, built from an array of directives joined with `; `.
- Allowlist covers GTM/GA4, swisstopo (`*.geo.admin.ch`), OpenFreeMap, and MapLibre's `blob:` workers/tiles, so the map-heavy `/projects/wo-haere/play` route keeps working.

## Additional Notes

Ships as **Report-Only** first: a wrong allowlist logs violations to the console instead of taking the site down; flipping to the enforcing header is a follow-up. This constrains *where* resources may load from — it is not an inline-XSS defence, since `script-src` keeps `'unsafe-inline'` (GTM injects inline scripts with no nonce, and the layout ships an inline JSON-LD script). Speed Insights beacons same-origin, so `'self'` covers it. Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)