### PR TITLE
chore(analytics): ship importable GTM container and setup runbook

### DIFF
--- a/gtm/README.md
+++ b/gtm/README.md
@@ -1,0 +1,128 @@
+# GTM container — setup runbook
+
+The GA4 tags, triggers and variables that turn this site's `dataLayer` pushes
+into GA4 events live in Google's UI, not the repo — unversioned, unreviewable,
+and a lot of clicking to reproduce. [`container.json`](./container.json) ships
+them as an importable Tag Manager export (`exportFormatVersion: 2`) so the whole
+GA4 configuration is version-controlled and rebuildable.
+
+GA4 is configured **inside** this container. The app loads only GTM
+(`<GoogleTagManager>` in `src/components/analytics/AnalyticsScripts.tsx`); there
+is no separate `<GoogleAnalytics>` script, so there is no double-tagging.
+
+## What the container contains
+
+- **1 Constant** — `GA4 Measurement ID`, the single place every tag reads the
+  `G-…` id from.
+- **20 Data Layer Variables** — one per event parameter across the stack, plus
+  one per user property (dot-notation, e.g. `user_properties.throw_count`).
+- **1 Google tag (GA4 config)** on *Initialization – All Pages*, with
+  `send_page_view: false`, a `traffic_type` field, and the six user properties.
+  It also fires on the `set_user_properties` event so the user properties
+  refresh once game state is known.
+- **9 GA4 Event tags** — one per client event, each on a Custom Event trigger
+  matching the `dataLayer` `event` name.
+- **Consent settings** requiring `analytics_storage` on every tag.
+- **Folders** per domain: `Site`, `wo-haere`, `Vitals`.
+
+Server-side events (`*_server`) are **not** in this container — they reach GA4
+directly through the Measurement Protocol
+(`src/lib/analytics/server/measurement-protocol.ts`) and bypass GTM entirely.
+They still need custom dimensions registered (see below).
+
+## Prerequisites
+
+- A **GA4 property** with a **Web data stream**. Its Measurement ID
+  (`G-XXXXXXXXXX`) is the value of `NEXT_PUBLIC_GA_ID`.
+- A GTM **web** container. Its public id (`GTM-XXXXXXX`) is the value of
+  `NEXT_PUBLIC_GTM_ID`.
+- Env vars set on the deployment (see [`.env.example`](../.env.example)):
+  `NEXT_PUBLIC_GTM_ID`, `NEXT_PUBLIC_GA_ID`, and — for the server layer —
+  `GA4_API_SECRET`. Unset ⇒ the whole analytics layer no-ops.
+
+## Import
+
+1. Tag Manager → **Admin → Import Container**.
+2. Choose [`container.json`](./container.json).
+3. Workspace: **Existing → Default Workspace** (or a new one).
+4. Import option: **Merge → Overwrite conflicting tags**.
+5. Confirm, then open the **`GA4 Measurement ID`** Constant and set its value to
+   your `NEXT_PUBLIC_GA_ID` (`G-7W2C85629N`). GTM can't read the Next.js env
+   var, so this Constant is the one value you set by hand.
+6. **Preview** the container against a deployment that has the real ids set, then
+   **Submit → Publish**.
+
+> **Heads-up.** GTM validates uploads against its own schema and can reject a
+> hand-authored export, and its field names drift between versions. Budget one
+> import/fix round trip; if the file won't take, build it by hand from the
+> [manual fallback](#manual-fallback) below — that path is the guarantee.
+
+## Three steps that are easy to lose a day to
+
+### 1. Register the event params as custom dimensions
+
+Event-scoped params are collected but **completely invisible in reports until
+registered** — the data looks lost when it isn't. GA4 Admin → **Custom
+definitions → Custom dimensions**, scope **Event**, one per param:
+
+`page_path`, `page_title`, `link_url`, `link_text`, `link_domain`,
+`nav_location`, `project_slug`, `cta_label`, `referrer`, `metric_name`,
+`metric_rating`, `metric_id`, `traffic_type` — plus the server params
+`art`, `upstream_ms`, `kanton`, `wasser`, `hoechi`, `distanz_km`, `richtig`,
+`grund`, `has_wurf`, `resolved`, `status`, `client_source`, `session_id`.
+
+- `metric_value` is numeric — register it as a **Custom metric** instead.
+- The six user properties — `throw_count`, `cantons_collected`,
+  `dart_skins_unlocked`, `color_scheme`, `reduced_motion`, `pointer_type` —
+  register as **User**-scoped custom dimensions.
+
+### 2. Switch off Enhanced Measurement page-change tracking
+
+`page_view` is sent from code (`PageViewTracker`). In the Web data stream →
+**Enhanced Measurement** → gear → turn **off** *"Page changes based on browser
+history events"*. Leaving it on double-counts every client-side navigation.
+
+### 3. Internal traffic + bots
+
+- Owner visits carry `traffic_type: internal` (set via `?ow_internal=1`; see
+  `src/lib/analytics/internal-traffic.ts`). Define the internal-traffic rule —
+  Web data stream → **Configure tag settings → Show all → Define internal
+  traffic** — matching `traffic_type` **equals** `internal`, then add the
+  matching **Data Filter** (Admin → **Data Settings → Data Filters**) and set it
+  to *Active*.
+- Confirm list-based **bot filtering** is enabled (Admin → Data Settings → Data
+  Collection); it excludes known bots and spiders.
+
+## Verify
+
+- **Preview / Tag Assistant** — navigate the site and confirm each `dataLayer`
+  event (`page_view`, `outbound_click`, …, `web_vitals`) fires its tag exactly
+  once, that the Google tag sends no automatic `page_view`, and that
+  `traffic_type` and the user properties populate.
+- **GA4 DebugView** — client events appear, and the server `*_server` events
+  land too (they need `GA4_API_SECRET`; verify separately since they skip GTM).
+
+## Manual fallback
+
+If the import is rejected, recreate it by hand in a fresh workspace. Order
+matters: variables → triggers → tags.
+
+1. **Constant** `GA4 Measurement ID` = your `NEXT_PUBLIC_GA_ID`.
+2. **Data Layer Variables** (Version 2), one per param name listed under
+   [custom dimensions](#1-register-the-event-params-as-custom-dimensions), plus
+   `user_properties.throw_count` and the other five user properties.
+3. **Custom Event triggers**, one per client event name: `page_view`,
+   `outbound_click`, `internal_link_click`, `nav_click`, `project_cta_click`,
+   `download_click`, `citation_click`, `page_not_found`, `web_vitals`, and
+   `set_user_properties`.
+4. **Google tag (GA4 config)** → tag id `{{GA4 Measurement ID}}`; set
+   `send_page_view` to `false`; add field `traffic_type` = `{{traffic_type}}`;
+   add the six user properties from their `{{user_properties.*}}` variables.
+   Triggers: *Initialization – All Pages* **and** the `set_user_properties`
+   Custom Event.
+5. **GA4 Event tag** per client event → *Measurement ID* = the Google tag above;
+   *Event Name* = the event; add its params as event parameters; trigger = the
+   matching Custom Event.
+6. On **every** tag, Consent Settings → *Require additional consent* →
+   `analytics_storage`.
+7. Optionally sort into `Site` / `wo-haere` / `Vitals` folders.

--- a/gtm/container.json
+++ b/gtm/container.json
@@ -1,0 +1,1038 @@
+{
+  "exportFormatVersion": 2,
+  "exportTime": "2026-08-18 00:00:00",
+  "containerVersion": {
+    "path": "accounts/0/containers/0/versions/0",
+    "accountId": "0",
+    "containerId": "0",
+    "containerVersionId": "0",
+    "name": "owieth portfolio — GA4",
+    "container": {
+      "path": "accounts/0/containers/0",
+      "accountId": "0",
+      "containerId": "0",
+      "name": "owieth portfolio",
+      "publicId": "GTM-XXXXXXX",
+      "usageContext": ["WEB"],
+      "fingerprint": "0",
+      "tagManagerUrl": "https://tagmanager.google.com/#/container/accounts/0/containers/0/workspaces/0"
+    },
+    "folder": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "folderId": "1",
+        "name": "Site",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "folderId": "2",
+        "name": "wo-haere",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "folderId": "3",
+        "name": "Vitals",
+        "fingerprint": "0"
+      }
+    ],
+    "variable": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "1",
+        "name": "GA4 Measurement ID",
+        "type": "c",
+        "parameter": [
+          {
+            "type": "template",
+            "key": "value",
+            "value": "G-XXXXXXXXXX"
+          }
+        ],
+        "notes": "Set this to the repo's NEXT_PUBLIC_GA_ID value (currently G-7W2C85629N). GTM cannot read the Next.js env var, so this Constant is the single place the tags read the Measurement ID from.",
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "2",
+        "name": "DLV - page_path",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "page_path" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "3",
+        "name": "DLV - page_title",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "page_title" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "4",
+        "name": "DLV - link_url",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "link_url" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "5",
+        "name": "DLV - link_text",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "link_text" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "6",
+        "name": "DLV - link_domain",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "link_domain" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "7",
+        "name": "DLV - nav_location",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "nav_location" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "8",
+        "name": "DLV - project_slug",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "project_slug" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "9",
+        "name": "DLV - cta_label",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "cta_label" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "10",
+        "name": "DLV - referrer",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "referrer" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "11",
+        "name": "DLV - traffic_type",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "traffic_type" }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "12",
+        "name": "DLV - metric_name",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "metric_name" }
+        ],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "13",
+        "name": "DLV - metric_value",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "metric_value" }
+        ],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "14",
+        "name": "DLV - metric_rating",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "metric_rating" }
+        ],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "15",
+        "name": "DLV - metric_id",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "metric_id" }
+        ],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "16",
+        "name": "DLV - user_properties.throw_count",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.throw_count" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "17",
+        "name": "DLV - user_properties.cantons_collected",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.cantons_collected" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "18",
+        "name": "DLV - user_properties.dart_skins_unlocked",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.dart_skins_unlocked" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "19",
+        "name": "DLV - user_properties.color_scheme",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.color_scheme" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "20",
+        "name": "DLV - user_properties.reduced_motion",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.reduced_motion" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "variableId": "21",
+        "name": "DLV - user_properties.pointer_type",
+        "type": "v",
+        "parameter": [
+          { "type": "integer", "key": "dataLayerVersion", "value": "2" },
+          { "type": "boolean", "key": "setDefaultValue", "value": "false" },
+          { "type": "template", "key": "name", "value": "user_properties.pointer_type" }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      }
+    ],
+    "trigger": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "1",
+        "name": "CE - page_view",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "page_view" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "2",
+        "name": "CE - outbound_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "outbound_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "3",
+        "name": "CE - internal_link_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "internal_link_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "4",
+        "name": "CE - nav_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "nav_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "5",
+        "name": "CE - project_cta_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "project_cta_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "6",
+        "name": "CE - download_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "download_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "7",
+        "name": "CE - citation_click",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "citation_click" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "8",
+        "name": "CE - page_not_found",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "page_not_found" }
+            ]
+          }
+        ],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "9",
+        "name": "CE - web_vitals",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "web_vitals" }
+            ]
+          }
+        ],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "triggerId": "10",
+        "name": "CE - set_user_properties",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "EQUALS",
+            "parameter": [
+              { "type": "template", "key": "arg0", "value": "{{_event}}" },
+              { "type": "template", "key": "arg1", "value": "set_user_properties" }
+            ]
+          }
+        ],
+        "parentFolderId": "2",
+        "fingerprint": "0"
+      }
+    ],
+    "tag": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "1",
+        "name": "Google tag - GA4",
+        "type": "gaawc",
+        "parameter": [
+          { "type": "boolean", "key": "sendPageView", "value": "false" },
+          { "type": "template", "key": "measurementId", "value": "{{GA4 Measurement ID}}" },
+          {
+            "type": "list",
+            "key": "fieldsToSet",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "fieldName", "value": "traffic_type" },
+                  { "type": "template", "key": "value", "value": "{{DLV - traffic_type}}" }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "list",
+            "key": "userProperties",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "throw_count" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.throw_count}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "cantons_collected" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.cantons_collected}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "dart_skins_unlocked" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.dart_skins_unlocked}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "color_scheme" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.color_scheme}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "reduced_motion" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.reduced_motion}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "name", "value": "pointer_type" },
+                  { "type": "template", "key": "value", "value": "{{DLV - user_properties.pointer_type}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["2147479573", "10"],
+        "tagFiringOption": "ONCE_PER_EVENT",
+        "notes": "GA4 config. send_page_view is off because page_view is emitted from application code (PageViewTracker). Fires on Initialization and again on set_user_properties so the six user properties refresh once game state is known.",
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "2",
+        "name": "GA4 - page_view",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "page_view" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "page_path" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - page_path}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "page_title" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - page_title}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["1"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "3",
+        "name": "GA4 - outbound_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "outbound_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_url" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_url}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_text" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_text}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_domain" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_domain}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["2"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "4",
+        "name": "GA4 - internal_link_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "internal_link_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_url" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_url}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_text" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_text}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_domain" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_domain}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["3"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "5",
+        "name": "GA4 - nav_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "nav_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_url" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_url}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_text" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_text}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "nav_location" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - nav_location}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["4"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "6",
+        "name": "GA4 - project_cta_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "project_cta_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "project_slug" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - project_slug}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "cta_label" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - cta_label}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["5"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "7",
+        "name": "GA4 - download_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "download_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "project_slug" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - project_slug}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_url" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_url}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["6"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "8",
+        "name": "GA4 - citation_click",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "citation_click" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_url" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_url}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_text" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_text}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "link_domain" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - link_domain}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["7"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "9",
+        "name": "GA4 - page_not_found",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "page_not_found" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "page_path" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - page_path}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "referrer" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - referrer}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["8"],
+        "parentFolderId": "1",
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "tagId": "10",
+        "name": "GA4 - web_vitals",
+        "type": "gaawe",
+        "parameter": [
+          { "type": "template", "key": "eventName", "value": "web_vitals" },
+          { "type": "tag_reference", "key": "measurementId", "value": "Google tag - GA4" },
+          {
+            "type": "list",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "metric_name" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - metric_name}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "metric_value" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - metric_value}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "metric_rating" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - metric_rating}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "metric_id" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - metric_id}}" }
+                ]
+              },
+              {
+                "type": "map",
+                "map": [
+                  { "type": "template", "key": "parameter", "value": "page_path" },
+                  { "type": "template", "key": "parameterValue", "value": "{{DLV - page_path}}" }
+                ]
+              }
+            ]
+          }
+        ],
+        "consentSettings": {
+          "consentStatus": "NEEDED",
+          "consentType": {
+            "type": "list",
+            "list": [{ "type": "template", "value": "analytics_storage" }]
+          }
+        },
+        "firingTriggerId": ["9"],
+        "parentFolderId": "3",
+        "fingerprint": "0"
+      }
+    ],
+    "builtInVariable": [
+      {
+        "accountId": "0",
+        "containerId": "0",
+        "type": "EVENT",
+        "name": "Event"
+      }
+    ],
+    "fingerprint": "0"
+  }
+}


### PR DESCRIPTION
## Summary
The GA4 tags, triggers and variables that turn this site's `dataLayer` pushes into GA4 events lived only in Google's UI — unversioned, unreviewable, and a lot of clicking to reproduce. This ships them as a version-controlled, importable Tag Manager export plus a runbook so a fresh GA4/GTM setup is repeatable.

## Changes
- Add `gtm/container.json` — an `exportFormatVersion: 2` container:
  - A `GA4 Measurement ID` Constant (the single place tags read the `G-…` id).
  - A Data Layer Variable per event param across the stack, plus one per user property (dot-notation).
  - A Google tag (GA4 config) on *Initialization – All Pages* with `send_page_view: false`, a `traffic_type` field, and the six user properties; it re-fires on `set_user_properties` so user properties refresh once game state is known.
  - One GA4 Event tag per client event (`page_view`, `outbound_click`, `internal_link_click`, `nav_click`, `project_cta_click`, `download_click`, `citation_click`, `page_not_found`, `web_vitals`), each on a Custom Event trigger matching the `dataLayer` `event` name.
  - Consent settings requiring `analytics_storage` on every tag; folders per domain (`Site` / `wo-haere` / `Vitals`).
- Add `gtm/README.md` — the runbook: import steps (Merge → Overwrite conflicting tags), the three easy-to-miss GA4 steps (register event params as custom dimensions, disable Enhanced Measurement history page-views, define internal-traffic + bot filtering), a server-events note, and a manual click-by-click fallback.

## Additional Notes
- Server-side `*_server` events are intentionally **not** in the container — they reach GA4 via the Measurement Protocol and bypass GTM; their params are still listed in the runbook's custom-dimensions section.
- GTM validates uploads against its own schema and its field names drift between versions, so it may reject a hand-authored export. Budget one import/fix round trip; the manual fallback in the README is the guarantee.
- The `GA4 Measurement ID` Constant ships as a placeholder — set it at import to the repo's `NEXT_PUBLIC_GA_ID`, which stays the source of truth (GTM can't read the Next.js env var).

Part of #397. Closes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)