### PR TITLE
feat(wo-haere): track the throw funnel

### DIFF
--- a/src/components/wo-haere/Wandcharte.tsx
+++ b/src/components/wo-haere/Wandcharte.tsx
@@ -11,6 +11,7 @@ import {
 import { Map as MlMap, Marker, type StyleSpecification } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
+import { track } from '@/lib/analytics/track';
 import { CH_BOUNDS, type LatLon } from '@/lib/wo-haere/geo/ch';
 import {
   CHARTE_STYLE,
@@ -81,6 +82,8 @@ export default function Wandcharte({
   const mapRef = useRef<MlMap | null>(null);
   const markerRef = useRef<Marker[]>([]);
   const rotationRef = useRef<number | null>(null);
+  // First user touch of the globe, tracked once for the component's lifetime.
+  const hasEngagedRef = useRef(false);
   const styleModeRef = useRef<StyleMode>(
     aasicht === 'charte' ? 'papier' : 'wäut',
   );
@@ -99,6 +102,16 @@ export default function Wandcharte({
       rotationRef.current = null;
     }
   }, []);
+
+  // The first mousedown/touchstart/wheel that halts the idle spin: a genuine
+  // user engagement, reported once. `stopRotation` also fires programmatically
+  // (zeigOrt, view changes, cleanup), so tracking lives here, not in it.
+  const engage = useCallback(() => {
+    stopRotation();
+    if (hasEngagedRef.current) return;
+    hasEngagedRef.current = true;
+    track({ name: 'map_engaged' });
+  }, [stopRotation]);
 
   /** Slow idle spin on the globe, paused as soon as the user grabs it. */
   const startRotation = useCallback(
@@ -219,9 +232,9 @@ export default function Wandcharte({
       syncStyle();
     };
     map.on('style.load', onStyleLoad);
-    map.on('mousedown', stopRotation);
-    map.on('touchstart', stopRotation);
-    map.on('wheel', stopRotation);
+    map.on('mousedown', engage);
+    map.on('touchstart', engage);
+    map.on('wheel', engage);
     map.once('load', () => onZwaegRef.current?.());
 
     return () => {
@@ -233,7 +246,7 @@ export default function Wandcharte({
       if (ctxRef.current === ctx) ctxRef.current = null;
     };
     // The map is created once; the view mode is read from a ref.
-  }, [stopRotation, syncStyle]);
+  }, [engage, stopRotation, syncStyle]);
 
   // Move the camera when the view mode changes.
   useEffect(() => {

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useRef, useState } from 'react';
 
+import { track } from '@/lib/analytics/track';
 import Pfyl from '@/components/wo-haere/Pfyl';
 import Resultatcharte, {
   type Resultat,
@@ -63,6 +64,9 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
   const [ziel, setZiel] = useState<{ x: number; y: number } | null>(null);
   const [wurfNr, setWurfNr] = useState(0);
   const [stil, setStil] = useState<WurfStil>('sufer');
+  // The throw's own style, captured at launch so the completion event can carry
+  // it once the API resolves — a ref so `zeigResultat` need not depend on it.
+  const stilRef = useRef<WurfStil>('sufer');
   const [wartendOrt, setWartendOrt] = useState<LatLon | null>(null);
   const [resultat, setResultat] = useState<Resultat | null>(null);
   const [laufend, setLaufend] = useState(false);
@@ -101,6 +105,27 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
         isPreich,
       };
       merkWurf(eintrag);
+
+      track(
+        wurf.art === 'preich'
+          ? {
+              name: 'throw_completed',
+              outcome: 'preich',
+              throw_quality: stilRef.current,
+              canton: wurf.kanton,
+              municipality: wurf.gmeind,
+              elevation: wurf.hoechi,
+              distance_km: wurf.distanzKm,
+              bearing: wurf.richtig,
+              water: wurf.wasser,
+            }
+          : {
+              name: 'throw_completed',
+              outcome: 'dernaebe',
+              throw_quality: stilRef.current,
+              miss_reason: wurf.grund,
+            },
+      );
     },
     [merkWurf, yschtellige.ton],
   );
@@ -115,8 +140,14 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
         });
         if (!res.ok) throw new Error(String(res.status));
         zeigResultat((await res.json()) as Wurf, ort);
-      } catch {
+      } catch (error) {
         setFähler(true);
+        const status =
+          error instanceof Error ? Number.parseInt(error.message, 10) : NaN;
+        track({
+          name: 'throw_api_error',
+          status: Number.isNaN(status) ? null : status,
+        });
       } finally {
         setLaufend(false);
       }
@@ -135,6 +166,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       setTeiletext(AKTIONE.teile);
       setWurfNr(n => n + 1);
       setStil(wurfStil);
+      stilRef.current = wurfStil;
 
       const container = handle.container();
 
@@ -178,6 +210,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
       });
       if (yschtellige.ton) tonDernaebe();
       setLaufend(false);
+      track({ name: 'throw_off_map' });
       return;
     }
 
@@ -191,6 +224,7 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
    */
   const charteZwaeg = useCallback(() => {
     if (!startWurf) return;
+    track({ name: 'shared_throw_opened' });
     const handle = charteRef.current;
     handle?.zeigOrt(startWurf);
     setWurfNr(n => n + 1);
@@ -304,7 +338,10 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
           type="button"
           aria-label={YTEXT.titu}
           aria-expanded={paneeOffe}
-          onClick={() => setPaneeOffe(o => !o)}
+          onClick={() => {
+            track({ name: 'panel_toggle', open: !paneeOffe });
+            setPaneeOffe(o => !o);
+          }}
           className="pointer-events-auto grid size-10 place-items-center rounded-xl bg-white/90 text-lg shadow-lg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 dark:bg-stone-900/90"
         >
           {paneeOffe ? '✕' : '☰'}

--- a/src/components/wo-haere/Wurfsteuerig.tsx
+++ b/src/components/wo-haere/Wurfsteuerig.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { track } from '@/lib/analytics/track';
 import { AKTIONE, WURFARTE } from '@/lib/wo-haere/data/bern';
 import { cn } from '@/lib/wo-haere/cn';
 import { startZieh, whoosh, type ZiehTon } from '@/lib/wo-haere/ton';
@@ -74,6 +75,9 @@ export default function Wurfsteuerig({
 
   const art = wurfart === 'schlüder' ? ZUG_ART.schlüder : ZUG_ART.zieh;
 
+  // The pointer-drag path serves both drag modes; the mode names the method.
+  const dragMethod = wurfart === 'schlüder' ? 'fling' : 'drag';
+
   /** The dart's resting spot, in map-container pixels. */
   const startPixel = useCallback(() => {
     const h = handleRef.current?.getBoundingClientRect();
@@ -112,8 +116,9 @@ export default function Wurfsteuerig({
       setChraft(0);
       // The pointer press is the gesture that lets audio start at all.
       if (ton) ziehTonRef.current = startZieh();
+      track({ name: 'throw_started', input_method: dragMethod });
     },
-    [gsperrt, startPixel, ton],
+    [dragMethod, gsperrt, startPixel, ton],
   );
 
   const bewege = useCallback(
@@ -151,12 +156,16 @@ export default function Wurfsteuerig({
     if (!zug) return;
 
     const v = vorschau(zug, art);
-    if (!v.gnue) return;
+    if (!v.gnue) {
+      track({ name: 'throw_abandoned', input_method: dragMethod });
+      return;
+    }
 
     const erg = zugZieu(zug, art, nöieWind(), brettRadius());
     if (ton) whoosh(v.chraft, erg.stil === 'chnorz');
+    track({ name: 'throw_input_method', input_method: dragMethod });
     onWurf(erg);
-  }, [art, brettRadius, onWurf, onZug, ton, tonUs, zieht]);
+  }, [art, brettRadius, dragMethod, onWurf, onZug, ton, tonUs, zieht]);
 
   if (wurfart === 'tipp') {
     return (
@@ -167,6 +176,7 @@ export default function Wurfsteuerig({
           onClick={() => {
             const erg = tippZieu(nöieWind());
             if (ton) whoosh(0.7, erg.stil === 'chnorz');
+            track({ name: 'throw_input_method', input_method: 'tap' });
             onWurf(erg);
           }}
           className={cn(
@@ -214,6 +224,7 @@ export default function Wurfsteuerig({
             brettRadius(),
           );
           if (ton) whoosh(0.57, erg.stil === 'chnorz');
+          track({ name: 'throw_input_method', input_method: 'keyboard' });
           onWurf(erg);
         }}
         className={cn(

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -66,6 +66,40 @@ describe('isValidEvent', () => {
     for (const event of events) expect(isValidEvent(event)).toBe(true);
   });
 
+  it('accepts the wo-haere throw funnel events', () => {
+    const events: AnalyticsEvent[] = [
+      { name: 'throw_started', input_method: 'drag' },
+      { name: 'throw_input_method', input_method: 'fling' },
+      { name: 'throw_input_method', input_method: 'tap' },
+      { name: 'throw_input_method', input_method: 'keyboard' },
+      { name: 'throw_abandoned', input_method: 'drag' },
+      {
+        name: 'throw_completed',
+        outcome: 'preich',
+        throw_quality: 'sufer',
+        canton: 'BE',
+        municipality: 'Bern',
+        elevation: 542,
+        distance_km: 0,
+        bearing: 'N',
+        water: false,
+      },
+      {
+        name: 'throw_completed',
+        outcome: 'dernaebe',
+        throw_quality: 'chnorz',
+        miss_reason: 'usland',
+      },
+      { name: 'throw_off_map' },
+      { name: 'throw_api_error', status: 500 },
+      { name: 'shared_throw_opened' },
+      { name: 'panel_toggle', open: true },
+      { name: 'map_engaged' },
+    ];
+
+    for (const event of events) expect(isValidEvent(event)).toBe(true);
+  });
+
   it('accepts the seeded web_vitals event', () => {
     expect(
       isValidEvent({

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,3 +1,6 @@
+import type { DernaebeGrund } from '@/lib/wo-haere/geo/resolveHit';
+import type { WurfStil } from '@/lib/wo-haere/throw/mechanics';
+
 /**
  * The event contract. Every later analytics layer adds a member to this
  * discriminated union rather than inventing its own push shape, so the whole
@@ -67,6 +70,73 @@ export type WebVitalsEvent = {
   page_path: string;
 };
 
+/**
+ * The Wo häre? throw funnel. The client is the single source of truth for these
+ * — the server layer emits `_server`-suffixed names so nothing double-counts.
+ *
+ * `input_method` names the throw mechanism: `tap` is the tipp-mode button,
+ * `drag` and `fling` are the two pointer-drag modes (zieh / schlüder), and
+ * `keyboard` is the Enter/Space fallback. `throw_started` and `throw_abandoned`
+ * only exist on the pointer-drag path, so they carry `drag` | `fling` only.
+ */
+export type ThrowInputMethod = 'drag' | 'tap' | 'fling' | 'keyboard';
+
+export type ThrowStartedEvent = {
+  name: 'throw_started';
+  input_method: 'drag' | 'fling';
+};
+
+export type ThrowInputMethodEvent = {
+  name: 'throw_input_method';
+  input_method: ThrowInputMethod;
+};
+
+export type ThrowAbandonedEvent = {
+  name: 'throw_abandoned';
+  input_method: 'drag' | 'fling';
+};
+
+/**
+ * The geography `zeigResultat()` already has in hand. A `preich` hit carries the
+ * full place; a `dernaebe` miss carries only why it missed (abroad vs border
+ * water). `throw_quality` is the throw's own style, independent of where it
+ * landed.
+ */
+export type ThrowCompletedEvent = {
+  name: 'throw_completed';
+  outcome: 'preich' | 'dernaebe';
+  throw_quality: WurfStil;
+  canton?: string;
+  municipality?: string;
+  elevation?: number | null;
+  distance_km?: number;
+  bearing?: string;
+  water?: boolean;
+  miss_reason?: DernaebeGrund;
+};
+
+export type ThrowOffMapEvent = {
+  name: 'throw_off_map';
+};
+
+export type ThrowApiErrorEvent = {
+  name: 'throw_api_error';
+  status?: number | null;
+};
+
+export type SharedThrowOpenedEvent = {
+  name: 'shared_throw_opened';
+};
+
+export type PanelToggleEvent = {
+  name: 'panel_toggle';
+  open: boolean;
+};
+
+export type MapEngagedEvent = {
+  name: 'map_engaged';
+};
+
 export type AnalyticsEvent =
   | PageViewEvent
   | OutboundClickEvent
@@ -76,7 +146,16 @@ export type AnalyticsEvent =
   | DownloadClickEvent
   | CitationClickEvent
   | PageNotFoundEvent
-  | WebVitalsEvent;
+  | WebVitalsEvent
+  | ThrowStartedEvent
+  | ThrowInputMethodEvent
+  | ThrowAbandonedEvent
+  | ThrowCompletedEvent
+  | ThrowOffMapEvent
+  | ThrowApiErrorEvent
+  | SharedThrowOpenedEvent
+  | PanelToggleEvent
+  | MapEngagedEvent;
 
 /**
  * GA4 silently drops an event whose name exceeds 40 characters or that carries


### PR DESCRIPTION
## Summary
Wo häre? is the site's only real interaction surface, and every gesture in it was invisible to analytics. This adds the throw-funnel layer so we can finally judge whether the drag-to-throw gesture is discoverable (the `throw_abandoned` drop-off being the single most useful number). Client-only by design — the server layer keeps its `_server`-suffixed names so nothing double-counts.

## Changes
- Add nine throw-funnel members to the `AnalyticsEvent` contract and pin them against the GA4 limits in `events.test.ts`.
- `Wurfsteuerig.tsx`: emit `throw_started` (drag entry), `throw_abandoned` (below-force discard), and `throw_input_method` (`drag`/`tap`/`fling`/`keyboard`) on every committed throw.
- `WoHaere.tsx`: emit `throw_completed` (full resolved geography + throw quality), `throw_api_error`, `throw_off_map`, `shared_throw_opened`, and `panel_toggle`.
- `Wandcharte.tsx`: emit `map_engaged` once on the first mousedown/touchstart/wheel that halts the idle globe spin, guarded so programmatic stops never fire it.

## Additional Notes
`throw_off_map` is kept distinct from an API miss, and `throw_completed` carries `miss_reason` on an abroad/border-water miss. Verified with `tsc`, `vitest` (196 passing), and `eslint`. Closes #402