### PR TITLE
feat(wo-haere): track share, settings, throw log and canton collection

### DIFF
--- a/src/components/wo-haere/Resultatcharte.tsx
+++ b/src/components/wo-haere/Resultatcharte.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from 'motion/react';
 
+import { track } from '@/lib/analytics/track';
 import {
   AKTIONE,
   DERNAEBE,
@@ -119,7 +120,10 @@ export default function Resultatcharte({
       <div className="mt-5 flex flex-wrap gap-2">
         <button
           type="button"
-          onClick={onNomau}
+          onClick={() => {
+            track({ name: 'result_action', action: 'again' });
+            onNomau();
+          }}
           className={cn(
             'rounded-full bg-red-600 px-5 py-2 font-bold text-white',
             'transition-transform duration-150 ease-out active:scale-95',
@@ -132,14 +136,20 @@ export default function Resultatcharte({
           <>
             <button
               type="button"
-              onClick={onZeig}
+              onClick={() => {
+                track({ name: 'result_action', action: 'show_on_map' });
+                onZeig();
+              }}
               className="rounded-full border border-stone-300 px-5 py-2 font-medium text-stone-800 transition-colors duration-150 ease-out hover:bg-stone-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 dark:border-stone-600 dark:text-stone-100 dark:hover:bg-stone-800"
             >
               {AKTIONE.ufDCharte}
             </button>
             <button
               type="button"
-              onClick={onTeile}
+              onClick={() => {
+                track({ name: 'result_action', action: 'share' });
+                onTeile();
+              }}
               className="rounded-full border border-stone-300 px-5 py-2 font-medium text-stone-800 transition-colors duration-150 ease-out hover:bg-stone-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 dark:border-stone-600 dark:text-stone-100 dark:hover:bg-stone-800"
             >
               {teiletext}

--- a/src/components/wo-haere/WoHaere.tsx
+++ b/src/components/wo-haere/WoHaere.tsx
@@ -19,10 +19,13 @@ import Yschtellige from '@/components/wo-haere/Yschtellige';
 import Zieuhilf from '@/components/wo-haere/Zieuhilf';
 // Attribution is not rendered here: maplibre shows it from the source specs
 // (© swisstopo on the raster source, OpenFreeMap/OSM from the world style).
+import { track } from '@/lib/analytics/track';
 import {
   AKTIONE,
   APP,
+  AUI_KANTOEN,
   FAEHLER,
+  PFYLSORTE,
   YSCHTELLIGE as YTEXT,
 } from '@/lib/wo-haere/data/bern';
 import { cn } from '@/lib/wo-haere/cn';
@@ -101,8 +104,42 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
         isPreich,
       };
       merkWurf(eintrag);
+
+      // Milestones fire on the state transition this throw causes, read from the
+      // pre-throw snapshot rather than a render-derived flag that would misfire
+      // when the settings pane mounts.
+      const vorherKantoene = gsammleteKantöne(wurfbuech);
+      if (
+        wurf.art === 'preich' &&
+        wurf.kanton &&
+        !vorherKantoene.has(wurf.kanton)
+      ) {
+        const cantonsCollected = vorherKantoene.size + 1;
+        track({
+          name: 'canton_collected',
+          canton: wurf.kanton,
+          cantons_collected: cantonsCollected,
+        });
+        if (cantonsCollected === AUI_KANTOEN.length) {
+          track({
+            name: 'all_cantons_collected',
+            throw_count: wurfbuech.length + 1,
+          });
+        }
+      }
+
+      const neuiZahl = wurfbuech.length + 1;
+      for (const sorte of PFYLSORTE) {
+        if (sorte.abNWuerf > 0 && sorte.abNWuerf === neuiZahl) {
+          track({
+            name: 'dart_skin_unlocked',
+            dart_skin: sorte.id,
+            threshold: sorte.abNWuerf,
+          });
+        }
+      }
     },
-    [merkWurf, yschtellige.ton],
+    [merkWurf, wurfbuech, yschtellige.ton],
   );
 
   const holResultat = useCallback(
@@ -207,31 +244,56 @@ export default function WoHaere({ startWurf }: WoHaereProps) {
     const url = `${window.location.origin}${PLAY_PATH}?wurf=${formatWurf({ lat, lon })}`;
     const daten = { title: APP.name, text: APP.tagline, url };
 
+    track({ name: 'share_attempt' });
+
     // navigator.share spends the transient activation from the button press,
     // so nothing may be awaited before it.
     if (navigator.canShare?.(daten)) {
       try {
         await navigator.share(daten);
         setTeiletext(AKTIONE.gteilt);
+        track({ name: 'share_result', share_method: 'native', outcome: 'shared' });
         return;
       } catch (error) {
         // Dismissing the sheet is a choice, not a failure. Anything else
         // falls through to the clipboard.
-        if (error instanceof Error && error.name === 'AbortError') return;
+        if (error instanceof Error && error.name === 'AbortError') {
+          track({
+            name: 'share_result',
+            share_method: 'native',
+            outcome: 'dismissed',
+          });
+          return;
+        }
       }
     }
 
     // navigator.clipboard is undefined outside a secure context.
     if (!navigator.clipboard) {
       setTeiletext(AKTIONE.nidTeilt);
+      track({
+        name: 'share_result',
+        share_method: 'clipboard',
+        outcome: 'unsupported',
+      });
       return;
     }
 
     try {
       await navigator.clipboard.writeText(url);
       setTeiletext(AKTIONE.kopiert);
+      track({
+        name: 'share_result',
+        share_method: 'clipboard',
+        outcome: 'copied',
+      });
     } catch {
       setTeiletext(AKTIONE.nidTeilt);
+      track({
+        name: 'share_result',
+        share_method: 'clipboard',
+        outcome: 'failed',
+      });
     }
   }, [resultat]);
 

--- a/src/components/wo-haere/Wurfbuech.tsx
+++ b/src/components/wo-haere/Wurfbuech.tsx
@@ -2,6 +2,7 @@
 
 import { AlertDialog } from '@base-ui/react/alert-dialog';
 
+import { track } from '@/lib/analytics/track';
 import { WURFBUECH as TEXT, kantonsName } from '@/lib/wo-haere/data/bern';
 import { cn } from '@/lib/wo-haere/cn';
 import type { WurfEintrag } from '@/lib/wo-haere/types';
@@ -39,7 +40,13 @@ export default function Wurfbuech({
               <li key={eintrag.id}>
                 <button
                   type="button"
-                  onClick={() => onZeig(eintrag)}
+                  onClick={() => {
+                    track({
+                      name: 'throw_log_entry_click',
+                      art: eintrag.wurf.art,
+                    });
+                    onZeig(eintrag);
+                  }}
                   className="flex w-full items-baseline justify-between gap-2 py-1.5 text-left text-sm hover:text-red-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 dark:hover:text-red-500"
                 >
                   <span className="truncate text-stone-800 dark:text-stone-200">
@@ -88,7 +95,13 @@ export default function Wurfbuech({
                     Nei
                   </AlertDialog.Close>
                   <AlertDialog.Close
-                    onClick={onLeere}
+                    onClick={() => {
+                      track({
+                        name: 'throw_log_cleared',
+                        entry_count: wurfbuech.length,
+                      });
+                      onLeere();
+                    }}
                     className="rounded-full bg-red-600 px-4 py-1.5 text-sm font-bold text-white hover:bg-red-700"
                   >
                     {TEXT.jaLeere}

--- a/src/components/wo-haere/Yschtellige.tsx
+++ b/src/components/wo-haere/Yschtellige.tsx
@@ -2,6 +2,7 @@
 
 import { Switch } from '@base-ui/react/switch';
 
+import { track } from '@/lib/analytics/track';
 import Wahl, { type WahlOption } from '@/components/wo-haere/Wahl';
 import {
   AASICHTE,
@@ -50,13 +51,27 @@ export default function Yschtellige({
         label={TEXT.aasicht}
         wert={wert.aasicht}
         optione={AASICHT_OPTIONE}
-        onWahl={aasicht => onÄndere({ aasicht })}
+        onWahl={aasicht => {
+          track({
+            name: 'setting_changed',
+            setting_name: 'view',
+            setting_value: aasicht,
+          });
+          onÄndere({ aasicht });
+        }}
       />
       <Wahl
         label={TEXT.wurfart}
         wert={wert.wurfart}
         optione={WURFART_OPTIONE}
-        onWahl={wurfart => onÄndere({ wurfart })}
+        onWahl={wurfart => {
+          track({
+            name: 'setting_changed',
+            setting_name: 'throw_style',
+            setting_value: wurfart,
+          });
+          onÄndere({ wurfart });
+        }}
       />
 
       {offeniSorte.length > 1 && (
@@ -67,7 +82,14 @@ export default function Yschtellige({
             id: s.id as PfylsorteId,
             name: `${s.emoji} ${s.name}`,
           }))}
-          onWahl={pfylsorte => onÄndere({ pfylsorte })}
+          onWahl={pfylsorte => {
+            track({
+              name: 'setting_changed',
+              setting_name: 'dart_skin',
+              setting_value: pfylsorte,
+            });
+            onÄndere({ pfylsorte });
+          }}
         />
       )}
 
@@ -77,7 +99,14 @@ export default function Yschtellige({
         </span>
         <Switch.Root
           checked={wert.ton}
-          onCheckedChange={ton => onÄndere({ ton })}
+          onCheckedChange={ton => {
+            track({
+              name: 'setting_changed',
+              setting_name: 'sound',
+              setting_value: ton ? 'on' : 'off',
+            });
+            onÄndere({ ton });
+          }}
           className={cn(
             'relative h-6 w-11 shrink-0 rounded-full bg-stone-300 transition-colors duration-150 ease-out',
             'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600',

--- a/src/lib/analytics/events.test.ts
+++ b/src/lib/analytics/events.test.ts
@@ -79,6 +79,40 @@ describe('isValidEvent', () => {
     ).toBe(true);
   });
 
+  it('accepts the wo-haere throw funnel events', () => {
+    const events: AnalyticsEvent[] = [
+      { name: 'share_attempt' },
+      { name: 'share_result', share_method: 'native', outcome: 'shared' },
+      { name: 'share_result', share_method: 'native', outcome: 'dismissed' },
+      { name: 'share_result', share_method: 'clipboard', outcome: 'copied' },
+      { name: 'share_result', share_method: 'clipboard', outcome: 'unsupported' },
+      { name: 'share_result', share_method: 'clipboard', outcome: 'failed' },
+      { name: 'result_action', action: 'again' },
+      { name: 'result_action', action: 'show_on_map' },
+      { name: 'result_action', action: 'share' },
+      { name: 'setting_changed', setting_name: 'view', setting_value: 'aaflug' },
+      {
+        name: 'setting_changed',
+        setting_name: 'throw_style',
+        setting_value: 'sufer',
+      },
+      {
+        name: 'setting_changed',
+        setting_name: 'dart_skin',
+        setting_value: 'alphorn',
+      },
+      { name: 'setting_changed', setting_name: 'sound', setting_value: 'off' },
+      { name: 'throw_log_entry_click', art: 'preich' },
+      { name: 'throw_log_entry_click', art: 'dernaebe' },
+      { name: 'throw_log_cleared', entry_count: 12 },
+      { name: 'canton_collected', canton: 'BE', cantons_collected: 1 },
+      { name: 'all_cantons_collected', throw_count: 42 },
+      { name: 'dart_skin_unlocked', dart_skin: 'alphorn', threshold: 30 },
+    ];
+
+    for (const event of events) expect(isValidEvent(event)).toBe(true);
+  });
+
   it('rejects a name longer than the limit', () => {
     const event = {
       name: 'x'.repeat(MAX_EVENT_NAME_LENGTH + 1),

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -67,6 +67,59 @@ export type WebVitalsEvent = {
   page_path: string;
 };
 
+/**
+ * wo-haere client throw funnel. Mirrors the server `*_server` funnel without the
+ * suffix (those belong to the server layer). Param values keep the game's raw
+ * Berndeutsch ids so they read the same as everywhere else in the feature.
+ */
+export type ShareAttemptEvent = {
+  name: 'share_attempt';
+};
+
+export type ShareResultEvent = {
+  name: 'share_result';
+  share_method: 'native' | 'clipboard';
+  outcome: 'shared' | 'dismissed' | 'copied' | 'unsupported' | 'failed';
+};
+
+export type ResultActionEvent = {
+  name: 'result_action';
+  action: 'again' | 'show_on_map' | 'share';
+};
+
+export type SettingChangedEvent = {
+  name: 'setting_changed';
+  setting_name: 'view' | 'throw_style' | 'dart_skin' | 'sound';
+  setting_value: string;
+};
+
+export type ThrowLogEntryClickEvent = {
+  name: 'throw_log_entry_click';
+  art: 'preich' | 'dernaebe';
+};
+
+export type ThrowLogClearedEvent = {
+  name: 'throw_log_cleared';
+  entry_count: number;
+};
+
+export type CantonCollectedEvent = {
+  name: 'canton_collected';
+  canton: string;
+  cantons_collected: number;
+};
+
+export type AllCantonsCollectedEvent = {
+  name: 'all_cantons_collected';
+  throw_count: number;
+};
+
+export type DartSkinUnlockedEvent = {
+  name: 'dart_skin_unlocked';
+  dart_skin: string;
+  threshold: number;
+};
+
 export type AnalyticsEvent =
   | PageViewEvent
   | OutboundClickEvent
@@ -76,7 +129,16 @@ export type AnalyticsEvent =
   | DownloadClickEvent
   | CitationClickEvent
   | PageNotFoundEvent
-  | WebVitalsEvent;
+  | WebVitalsEvent
+  | ShareAttemptEvent
+  | ShareResultEvent
+  | ResultActionEvent
+  | SettingChangedEvent
+  | ThrowLogEntryClickEvent
+  | ThrowLogClearedEvent
+  | CantonCollectedEvent
+  | AllCantonsCollectedEvent
+  | DartSkinUnlockedEvent;
 
 /**
  * GA4 silently drops an event whose name exceeds 40 characters or that carries


### PR DESCRIPTION
## Summary
Adds the client-side throw-funnel analytics for the wo-haere game, so we can see how the native share sheet performs, which default setting people abandon first, and whether the 30-throw / all-cantons retention milestones are ever reached. Stacks on the existing server funnel layer and reuses the typed `track()` contract.

## Changes
- Add 9 event types to the `AnalyticsEvent` union (`share_attempt`, `share_result`, `result_action`, `setting_changed`, `throw_log_entry_click`, `throw_log_cleared`, `canton_collected`, `all_cantons_collected`, `dart_skin_unlocked`) plus contract tests — no `_server` suffix, values keep the game's raw Berndeutsch ids.
- Instrument `WoHaere.tsx`: fire `share_attempt` + `share_result` across all five `teile()` outcomes (native shared/dismissed, clipboard copied/unsupported/failed), and detect `canton_collected` / `all_cantons_collected` / `dart_skin_unlocked` at the throw-record transition using the pre-throw snapshot.
- Instrument `Resultatcharte.tsx` (`result_action`), `Yschtellige.tsx` (`setting_changed` for view/throw style/dart skin/sound), and `Wurfbuech.tsx` (throw-log entry click and clear).

## Additional Notes
The issue's `bern.ts` / `Stampecharte.tsx` line refs were conceptual (a data array and a render-derived boolean); the milestone events fire at the throw transition point instead. Verified with `tsc --noEmit`, `pnpm lint`, and `pnpm test` (196 passing).

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)